### PR TITLE
feat: add InfluxDB CAN writer

### DIFF
--- a/embedded/sdkconfig.esp32dev
+++ b/embedded/sdkconfig.esp32dev
@@ -3317,6 +3317,17 @@ CONFIG_EPHOROS_CAN_TASK_PRIORITY=5
 # end of Ephoros CAN receiver
 
 #
+# InfluxDB telemetry
+#
+# default:
+CONFIG_EPHOROS_INFLUXDB_WRITE_URL=""
+# default:
+CONFIG_EPHOROS_INFLUXDB_TOKEN=""
+# default:
+CONFIG_EPHOROS_INFLUXDB_TIMEOUT_MS=10000
+# end of InfluxDB telemetry
+
+#
 # esp-modem
 #
 # default:

--- a/embedded/src/CMakeLists.txt
+++ b/embedded/src/CMakeLists.txt
@@ -13,5 +13,5 @@ endif()
 idf_component_register(
 	SRCS ${app_sources}
 	INCLUDE_DIRS ${app_include_dirs}
-	REQUIRES esp_modem esp_driver_twai
+	REQUIRES esp_http_client esp_modem esp_driver_twai mbedtls
 )

--- a/embedded/src/Kconfig
+++ b/embedded/src/Kconfig
@@ -179,3 +179,30 @@ config EPHOROS_CAN_VERA_DECODER
         until a project DBC is available.
 
 endmenu
+
+menu "InfluxDB telemetry"
+
+config EPHOROS_INFLUXDB_WRITE_URL
+	string "InfluxDB Write API URL"
+	default ""
+	help
+		The complete InfluxDB 2.x Write API URL, including its organization,
+		bucket, and precision query parameters. For example:
+		https://influx.example.com/api/v2/write?org=apex&bucket=telemetry&precision=ns
+
+config EPHOROS_INFLUXDB_TOKEN
+	string "InfluxDB API token"
+	default ""
+	help
+		An API token with write permission for the configured bucket. This value
+		is stored in sdkconfig, so do not commit a production token. Prefer NVS
+		or another device-provisioning mechanism for production firmware.
+
+config EPHOROS_INFLUXDB_TIMEOUT_MS
+	int "HTTP write timeout (ms)"
+	default 10000
+	range 1000 60000
+	help
+		Maximum time allowed for one InfluxDB write request.
+
+endmenu

--- a/embedded/src/influxdb.c
+++ b/embedded/src/influxdb.c
@@ -1,0 +1,127 @@
+#include "influxdb.h"
+
+#include <inttypes.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "esp_crt_bundle.h"
+#include "esp_http_client.h"
+#include "sdkconfig.h"
+
+#define INFLUXDB_DEFAULT_TIMEOUT_MS 10000
+#define INFLUXDB_LINE_BUFFER_SIZE 512
+
+static bool valid_config(const influxdb_config_t *config) {
+	return config != NULL && config->write_url != NULL &&
+		config->write_url[0] != '\0' && config->token != NULL &&
+		config->token[0] != '\0';
+}
+
+influxdb_config_t influxdb_config_from_kconfig(void) {
+	return (influxdb_config_t){
+		.write_url = CONFIG_EPHOROS_INFLUXDB_WRITE_URL,
+		.token = CONFIG_EPHOROS_INFLUXDB_TOKEN,
+		.timeout_ms = CONFIG_EPHOROS_INFLUXDB_TIMEOUT_MS,
+	};
+}
+
+esp_err_t influxdb_client_init(
+	influxdb_client_t *client,
+	const influxdb_config_t *config
+) {
+	if (client == NULL || !valid_config(config)) {
+		return ESP_ERR_INVALID_ARG;
+	}
+
+	client->config = *config;
+	if (client->config.timeout_ms <= 0) {
+		client->config.timeout_ms = INFLUXDB_DEFAULT_TIMEOUT_MS;
+	}
+
+	return ESP_OK;
+}
+
+esp_err_t influxdb_write_line(
+	const influxdb_client_t *client,
+	const char *line_protocol
+) {
+	if (client == NULL || !valid_config(&client->config) ||
+		line_protocol == NULL || line_protocol[0] == '\0') {
+		return ESP_ERR_INVALID_ARG;
+	}
+
+	const size_t authorization_size = strlen(client->config.token) +
+		strlen("Token ") + 1;
+	char *authorization = malloc(authorization_size);
+	if (authorization == NULL) {
+		return ESP_ERR_NO_MEM;
+	}
+	snprintf(authorization, authorization_size, "Token %s", client->config.token);
+
+	esp_http_client_config_t http_config = {
+		.url = client->config.write_url,
+		.timeout_ms = client->config.timeout_ms,
+		.crt_bundle_attach = esp_crt_bundle_attach,
+	};
+	esp_http_client_handle_t http = esp_http_client_init(&http_config);
+	if (http == NULL) {
+		free(authorization);
+		return ESP_ERR_NO_MEM;
+	}
+
+	esp_err_t err = esp_http_client_set_method(http, HTTP_METHOD_POST);
+	if (err == ESP_OK) {
+		err = esp_http_client_set_header(http, "Authorization", authorization);
+	}
+	if (err == ESP_OK) {
+		err = esp_http_client_set_header(http, "Content-Type", "text/plain; charset=utf-8");
+	}
+	if (err == ESP_OK) {
+		err = esp_http_client_set_post_field(http, line_protocol, strlen(line_protocol));
+	}
+	if (err == ESP_OK) {
+		err = esp_http_client_perform(http);
+	}
+	if (err == ESP_OK && esp_http_client_get_status_code(http) != 204) {
+		err = ESP_FAIL;
+	}
+
+	esp_http_client_cleanup(http);
+	free(authorization);
+	return err;
+}
+
+esp_err_t influxdb_write_number(
+	const influxdb_client_t *client,
+	const char *measurement,
+	const char *tag_key,
+	const char *tag_value,
+	const char *field_key,
+	double value,
+	int64_t timestamp_ns
+) {
+	if (measurement == NULL || tag_key == NULL || tag_value == NULL ||
+		field_key == NULL || !isfinite(value)) {
+		return ESP_ERR_INVALID_ARG;
+	}
+
+	char line_protocol[INFLUXDB_LINE_BUFFER_SIZE];
+	int written;
+	if (timestamp_ns == 0) {
+		written = snprintf(line_protocol, sizeof(line_protocol), "%s,%s=%s %s=%.17g",
+			measurement, tag_key, tag_value, field_key, value);
+	} else {
+		written = snprintf(line_protocol, sizeof(line_protocol),
+			"%s,%s=%s %s=%.17g %" PRId64,
+			measurement, tag_key, tag_value, field_key, value, timestamp_ns);
+	}
+
+	if (written < 0 || written >= (int)sizeof(line_protocol)) {
+		return ESP_ERR_INVALID_SIZE;
+	}
+
+	return influxdb_write_line(client, line_protocol);
+}

--- a/embedded/src/influxdb.h
+++ b/embedded/src/influxdb.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "esp_err.h"
+
+/**
+ * Connection details for an InfluxDB 2.x Write API endpoint.
+ *
+ * write_url must include the organization, bucket, and precision query
+ * parameters. For example:
+ * https://influx.example.com/api/v2/write?org=apex&bucket=telemetry&precision=ns
+ *
+ * token is an InfluxDB API token with write access to the configured bucket.
+ * Keep it out of source control; provision it from secure storage in production.
+ */
+typedef struct {
+	const char *write_url;
+	const char *token;
+	int timeout_ms;
+} influxdb_config_t;
+
+typedef struct {
+	influxdb_config_t config;
+} influxdb_client_t;
+
+/** Build an InfluxDB configuration from the Kconfig CONFIG_EPHOROS_INFLUXDB_* values. */
+influxdb_config_t influxdb_config_from_kconfig(void);
+
+/** Initialize an InfluxDB client. Does not perform network I/O. */
+esp_err_t influxdb_client_init(
+	influxdb_client_t *client,
+	const influxdb_config_t *config
+);
+
+/**
+ * Write one or more newline-separated Influx line-protocol points.
+ *
+ * A successful InfluxDB write returns HTTP 204. The line protocol is supplied
+ * by the caller so decoded CAN data can choose its own measurement, tags, and
+ * fields. Example: "can_signal,frame_id=0x123 speed=42.5 1735689600000000000".
+ */
+esp_err_t influxdb_write_line(
+	const influxdb_client_t *client,
+	const char *line_protocol
+);
+
+/**
+ * Convenience wrapper for a single numeric CAN signal.
+ *
+ * timestamp_ns is Unix time in nanoseconds. Pass 0 to let InfluxDB assign the
+ * server receive time. Measurement, tag, and field names must already follow
+ * Influx line-protocol escaping rules.
+ */
+esp_err_t influxdb_write_number(
+	const influxdb_client_t *client,
+	const char *measurement,
+	const char *tag_key,
+	const char *tag_value,
+	const char *field_key,
+	double value,
+	int64_t timestamp_ns
+);


### PR DESCRIPTION
## Summary

- Add an ESP-IDF InfluxDB 2.x client for writing line-protocol telemetry.
- Support configurable write URL, API token, and HTTP timeout through Kconfig.
- Add convenience support for numeric CAN signal writes with optional timestamps.
- Include required HTTP client and mbedTLS dependencies.

## Testing

- Not run.