### PR TITLE
feat: add InfluxDB dashboard provisioning

### DIFF
--- a/config/dashboards.go
+++ b/config/dashboards.go
@@ -5,9 +5,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ApexCorse/vera"
 	"github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/common"
 	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
 	"github.com/grafana/grafana-foundation-sdk/go/stat"
+	"github.com/grafana/grafana-foundation-sdk/go/timeseries"
 )
 
 const (
@@ -30,14 +33,19 @@ var (
 		Uid:  cog.ToPtr("mqtt-datasource"),
 		Type: cog.ToPtr("grafana-mqtt-datasource"),
 	}
+	influxDBDataSourceRef = dashboard.DataSourceRef{
+		Uid:  cog.ToPtr("influxdb-datasource"),
+		Type: cog.ToPtr("influxdb"),
+	}
 )
 
-// parseTopicHierarchy parses a list of MQTT topics into a hierarchical structure.
-// Topics are expected to follow the pattern: data/firstLevel/secondLevel
-func parseTopicHierarchy(topics []string) (map[string]map[string][]string, error) {
-	topicsMap := make(map[string]map[string][]string)
+// parseSignalTopicHierarchy groups DBC signal topics by their first two topic levels.
+// Topics are expected to follow the pattern: data/firstLevel/secondLevel.
+func parseSignalTopicHierarchy(signalTopics []vera.SignalTopic) (map[string]map[string][]vera.SignalTopic, error) {
+	topicsMap := make(map[string]map[string][]vera.SignalTopic)
 
-	for _, topic := range topics {
+	for _, signalTopic := range signalTopics {
+		topic := signalTopic.Topic
 		if !strings.HasPrefix(topic, topicPrefix) {
 			return nil, fmt.Errorf("each topic must start with '%s': %s", topicPrefix, topic)
 		}
@@ -57,31 +65,37 @@ func parseTopicHierarchy(topics []string) (map[string]map[string][]string, error
 		}
 
 		if _, exists := topicsMap[firstLevel]; !exists {
-			topicsMap[firstLevel] = make(map[string][]string)
+			topicsMap[firstLevel] = make(map[string][]vera.SignalTopic)
 		}
 
-		topicsMap[firstLevel][secondLevel] = append(topicsMap[firstLevel][secondLevel], topic)
+		topicsMap[firstLevel][secondLevel] = append(topicsMap[firstLevel][secondLevel], signalTopic)
 	}
 
 	return topicsMap, nil
 }
 
-// buildDashboardForLevel creates a dashboard for a given first-level topic hierarchy.
-func buildDashboardForLevel(firstLevel string, secondLevels map[string][]string) (dashboard.Dashboard, error) {
+// buildDashboardForLevel creates live MQTT and historical InfluxDB panels for every signal.
+func buildDashboardForLevel(firstLevel string, secondLevels map[string][]vera.SignalTopic) (dashboard.Dashboard, error) {
 	dashboardBuilder := dashboard.NewDashboardBuilder(firstLevel).
 		Uid(fmt.Sprintf("generated-%s", firstLevel)).
 		Refresh("1m").
 		Time("now-1m", "now")
 
-	for secondLevel, topics := range secondLevels {
+	for secondLevel, signalTopics := range secondLevels {
 		row := dashboard.NewRowBuilder(secondLevel)
 
-		for _, topic := range topics {
+		for _, signalTopic := range signalTopics {
 			row = row.WithPanel(
 				stat.NewPanelBuilder().
-					Title(topic).
+					Title(signalTopic.Topic + " (live)").
+					GraphMode(common.BigValueGraphModeNone).
 					Datasource(dataSourceRef).
-					WithTarget(NewMQTTQueryBuilder(topic)),
+					WithTarget(NewMQTTQueryBuilder(signalTopic.Topic)),
+			).WithPanel(
+				timeseries.NewPanelBuilder().
+					Title(signalTopic.Topic + " (history)").
+					Datasource(influxDBDataSourceRef).
+					WithTarget(NewInfluxDBQueryBuilder(signalTopic.Signal)),
 			)
 		}
 
@@ -91,9 +105,9 @@ func buildDashboardForLevel(firstLevel string, secondLevels map[string][]string)
 	return dashboardBuilder.Build()
 }
 
-// createDashboardsWithMQTTTopics generates Grafana dashboards from a list of MQTT topics.
-func createDashboardsWithMQTTTopics(topics []string) (map[string]dashboard.Dashboard, error) {
-	topicsMap, err := parseTopicHierarchy(topics)
+// createDashboardsWithSignalTopics generates Grafana dashboards from DBC signal-topic mappings.
+func createDashboardsWithSignalTopics(signalTopics []vera.SignalTopic) (map[string]dashboard.Dashboard, error) {
+	topicsMap, err := parseSignalTopicHierarchy(signalTopics)
 	if err != nil {
 		return nil, err
 	}

--- a/config/dashboards.go
+++ b/config/dashboards.go
@@ -95,7 +95,7 @@ func buildDashboardForLevel(firstLevel string, secondLevels map[string][]vera.Si
 				timeseries.NewPanelBuilder().
 					Title(signalTopic.Topic + " (history)").
 					Datasource(influxDBDataSourceRef).
-					WithTarget(NewInfluxDBQueryBuilder(signalTopic.Signal)),
+					WithTarget(NewInfluxDBQueryBuilder(signalTopic.Topic)),
 			)
 		}
 

--- a/config/dashboards_test.go
+++ b/config/dashboards_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/ApexCorse/vera"
+)
+
+func TestBuildDashboardForLevelPairsLiveAndHistoricalPanels(t *testing.T) {
+	dashboard, err := buildDashboardForLevel("powertrain", map[string][]vera.SignalTopic{
+		"engine": {{Signal: "EngineSpeed", Topic: "data/powertrain/engine-speed"}},
+	})
+	if err != nil {
+		t.Fatalf("build dashboard: %v", err)
+	}
+
+	encoded, err := json.Marshal(dashboard)
+	if err != nil {
+		t.Fatalf("marshal dashboard: %v", err)
+	}
+	json := string(encoded)
+
+	for _, expected := range []string{
+		"data/powertrain/engine-speed",
+		"grafana-mqtt-datasource",
+		`"graphMode":"none"`,
+		"influxdb-datasource",
+		`r[\"name\"] == \"EngineSpeed\"`,
+	} {
+		if !strings.Contains(json, expected) {
+			t.Errorf("generated dashboard does not contain %q", expected)
+		}
+	}
+}
+
+func TestInfluxDBQueryUsesSignalName(t *testing.T) {
+	query, err := NewInfluxDBQueryBuilder("BatteryVoltage").Build()
+	if err != nil {
+		t.Fatalf("build query: %v", err)
+	}
+
+	influxQuery, ok := query.(InfluxDBQuery)
+	if !ok {
+		t.Fatalf("query type = %T, want InfluxDBQuery", query)
+	}
+	if !strings.Contains(influxQuery.Query, `r["name"] == "BatteryVoltage"`) {
+		t.Errorf("query does not filter by the signal name: %s", influxQuery.Query)
+	}
+}

--- a/config/dashboards_test.go
+++ b/config/dashboards_test.go
@@ -27,7 +27,7 @@ func TestBuildDashboardForLevelPairsLiveAndHistoricalPanels(t *testing.T) {
 		"grafana-mqtt-datasource",
 		`"graphMode":"none"`,
 		"influxdb-datasource",
-		`r[\"name\"] == \"EngineSpeed\"`,
+		`r[\"topic\"] == \"data/powertrain/engine-speed\"`,
 	} {
 		if !strings.Contains(json, expected) {
 			t.Errorf("generated dashboard does not contain %q", expected)
@@ -35,8 +35,8 @@ func TestBuildDashboardForLevelPairsLiveAndHistoricalPanels(t *testing.T) {
 	}
 }
 
-func TestInfluxDBQueryUsesSignalName(t *testing.T) {
-	query, err := NewInfluxDBQueryBuilder("BatteryVoltage").Build()
+func TestInfluxDBQueryUsesMQTTTopic(t *testing.T) {
+	query, err := NewInfluxDBQueryBuilder("data/electrical/battery-voltage").Build()
 	if err != nil {
 		t.Fatalf("build query: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestInfluxDBQueryUsesSignalName(t *testing.T) {
 	if !ok {
 		t.Fatalf("query type = %T, want InfluxDBQuery", query)
 	}
-	if !strings.Contains(influxQuery.Query, `r["name"] == "BatteryVoltage"`) {
-		t.Errorf("query does not filter by the signal name: %s", influxQuery.Query)
+	if !strings.Contains(influxQuery.Query, `r["topic"] == "data/electrical/battery-voltage"`) {
+		t.Errorf("query does not filter by the MQTT topic: %s", influxQuery.Query)
 	}
 }

--- a/config/main.go
+++ b/config/main.go
@@ -34,9 +34,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	topics := getTopicsFromConfig(config)
-
-	dashboards, err := createDashboardsWithMQTTTopics(topics)
+	dashboards, err := createDashboardsWithSignalTopics(config.Topics)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
@@ -69,21 +67,13 @@ func main() {
 	}
 }
 
-func getTopicsFromConfig(config *vera.Config) []string {
-	topics := make([]string, len(config.Topics))
-	for i := range config.Topics {
-		topics[i] = config.Topics[i].Topic
-	}
-
-	return topics
-}
-
 func preconfigGrafana() {
 	// Required to correctly unmarshal panels and dataqueries
 	plugins.RegisterDefaultPlugins()
 
 	// This lets cog know about the newly created query type and how to unmarshal it.
 	cog.NewRuntime().RegisterDataqueryVariant(MQTTQueryVariantConfig())
+	cog.NewRuntime().RegisterDataqueryVariant(InfluxDBQueryVariantConfig())
 }
 
 func getDbcConfig() (*vera.Config, error) {

--- a/config/query.go
+++ b/config/query.go
@@ -2,10 +2,86 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
 
 	"github.com/grafana/grafana-foundation-sdk/go/cog"
 	"github.com/grafana/grafana-foundation-sdk/go/cog/variants"
 )
+
+const influxDBQueryTemplate = `from(bucket: %q)
+  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+  |> filter(fn: (r) => r["_measurement"] == "can_signal")
+  |> filter(fn: (r) => r["_field"] == "value")
+  |> filter(fn: (r) => r["name"] == %q)
+  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)
+  |> yield(name: "mean")`
+
+type InfluxDBQuery struct {
+	RefId        string `json:"refId"`
+	Hide         *bool  `json:"hide,omitempty"`
+	Query        string `json:"query"`
+	RawQuery     bool   `json:"rawQuery"`
+	ResultFormat string `json:"resultFormat"`
+}
+
+func (resource InfluxDBQuery) Equals(otherCandidate variants.Dataquery) bool {
+	other, ok := otherCandidate.(InfluxDBQuery)
+	return ok && resource.RefId == other.RefId && resource.Query == other.Query &&
+		resource.RawQuery == other.RawQuery && resource.ResultFormat == other.ResultFormat
+}
+
+func (resource InfluxDBQuery) Validate() error             { return nil }
+func (resource InfluxDBQuery) ImplementsDataqueryVariant() {}
+func (resource InfluxDBQuery) DataqueryType() string       { return "influxdb" }
+
+func InfluxDBQueryVariantConfig() variants.DataqueryConfig {
+	return variants.DataqueryConfig{
+		Identifier: "influxdb",
+		DataqueryUnmarshaler: func(raw []byte) (variants.Dataquery, error) {
+			dataquery := &InfluxDBQuery{}
+			if err := json.Unmarshal(raw, dataquery); err != nil {
+				return nil, err
+			}
+			return dataquery, nil
+		},
+	}
+}
+
+var _ cog.Builder[variants.Dataquery] = (*InfluxDBQueryBuilder)(nil)
+
+type InfluxDBQueryBuilder struct{ internal *InfluxDBQuery }
+
+func NewInfluxDBQueryBuilder(signal string) *InfluxDBQueryBuilder {
+	return &InfluxDBQueryBuilder{internal: &InfluxDBQuery{
+		Query:    fmt.Sprintf(influxDBQueryTemplate, influxDBBucket(), signal),
+		RawQuery: true, ResultFormat: "time_series",
+	}}
+}
+
+func influxDBBucket() string {
+	if bucket := os.Getenv("INFLUXDB_INIT_BUCKET"); bucket != "" {
+		return bucket
+	}
+	return "telemetry"
+}
+
+func (builder *InfluxDBQueryBuilder) Build() (variants.Dataquery, error) {
+	if err := builder.internal.Validate(); err != nil {
+		return InfluxDBQuery{}, err
+	}
+	return *builder.internal, nil
+}
+
+func (builder *InfluxDBQueryBuilder) RefId(refId string) *InfluxDBQueryBuilder {
+	builder.internal.RefId = refId
+	return builder
+}
+
+func (builder *InfluxDBQueryBuilder) Hide(hide bool) *InfluxDBQueryBuilder {
+	builder.internal.Hide = &hide
+	return builder
+}
 
 type MQTTQuery struct {
 	RefId string `json:"refId"`

--- a/config/query.go
+++ b/config/query.go
@@ -13,7 +13,7 @@ const influxDBQueryTemplate = `from(bucket: %q)
   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
   |> filter(fn: (r) => r["_measurement"] == "can_signal")
   |> filter(fn: (r) => r["_field"] == "value")
-  |> filter(fn: (r) => r["name"] == %q)
+  |> filter(fn: (r) => r["topic"] == %q)
   |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)
   |> yield(name: "mean")`
 
@@ -52,9 +52,9 @@ var _ cog.Builder[variants.Dataquery] = (*InfluxDBQueryBuilder)(nil)
 
 type InfluxDBQueryBuilder struct{ internal *InfluxDBQuery }
 
-func NewInfluxDBQueryBuilder(signal string) *InfluxDBQueryBuilder {
+func NewInfluxDBQueryBuilder(topic string) *InfluxDBQueryBuilder {
 	return &InfluxDBQueryBuilder{internal: &InfluxDBQuery{
-		Query:    fmt.Sprintf(influxDBQueryTemplate, influxDBBucket(), signal),
+		Query:    fmt.Sprintf(influxDBQueryTemplate, influxDBBucket(), topic),
 		RawQuery: true, ResultFormat: "time_series",
 	}}
 }

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -12,6 +12,7 @@ services:
     environment:
       - DBC_FILE_PATH=/opt/config.dbc
       - DASHBOARDS_PATH=/opt/grafana/provisioning/dashboards/
+      - INFLUXDB_INIT_BUCKET=${INFLUXDB_INIT_BUCKET:-telemetry}
   broker:
     image: emqx/emqx-enterprise:5.10.0
     hostname: docker.emqx.com
@@ -33,11 +34,34 @@ services:
       timeout: 10s
       retries: 5
       start_period: 30s
+  influxdb:
+    image: influxdb:2.7
+    environment:
+      - DOCKER_INFLUXDB_INIT_MODE=setup
+      - DOCKER_INFLUXDB_INIT_USERNAME=${INFLUXDB_INIT_USERNAME:-admin}
+      - DOCKER_INFLUXDB_INIT_PASSWORD=${INFLUXDB_INIT_PASSWORD:-ephoros-dev-password}
+      - DOCKER_INFLUXDB_INIT_ORG=${INFLUXDB_INIT_ORG:-ephoros}
+      - DOCKER_INFLUXDB_INIT_BUCKET=${INFLUXDB_INIT_BUCKET:-telemetry}
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=${INFLUXDB_TOKEN:-ephoros-dev-token}
+    ports:
+      - 8086:8086
+    volumes:
+      - influxdb-data:/var/lib/influxdb2
+      - influxdb-config:/etc/influxdb2
+    healthcheck:
+      test: ["CMD", "influx", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
   client:
     image: grafana/grafana
     environment:
       - GF_PLUGINS_PREINSTALL=grafana-mqtt-datasource
       - GF_DASHBOARDS_MIN_REFRESH_INTERVAL=1s
+      - INFLUXDB_TOKEN=${INFLUXDB_TOKEN:-ephoros-dev-token}
+      - INFLUXDB_INIT_ORG=${INFLUXDB_INIT_ORG:-ephoros}
+      - INFLUXDB_INIT_BUCKET=${INFLUXDB_INIT_BUCKET:-telemetry}
     env_file: ../.env
     networks:
       - default
@@ -48,6 +72,8 @@ services:
         condition: service_healthy
       config:
         condition: service_completed_successfully
+      influxdb:
+        condition: service_healthy
     volumes:
       - ../grafana/provisioning:/etc/grafana/provisioning
       - ../grafana/provisioning/dashboards:/var/lib/grafana/dashboards
@@ -55,3 +81,7 @@ services:
 networks:
   default:
     driver: bridge
+
+volumes:
+  influxdb-data:
+  influxdb-config:

--- a/embedded/platformio.ini
+++ b/embedded/platformio.ini
@@ -9,6 +9,6 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32dev]
-platform = espressif32
+platform = espressif32@7.0.1
 board = esp32dev
 framework = espidf

--- a/embedded/src/influxdb.c
+++ b/embedded/src/influxdb.c
@@ -48,8 +48,8 @@ static void influxdb_task(void *arg) {
 		}
 
 		/* TWAI timestamps are not Unix timestamps, so let InfluxDB assign it. */
-		esp_err_t err = influxdb_write_number(client, "can_signal", "name",
-								signal.name, "value", signal.value, 0);
+		esp_err_t err = influxdb_write_number(client, "can_signal", "topic",
+								signal.topic, "value", signal.value, 0);
 		if (err != ESP_OK) {
 			ESP_LOGW(TAG, "failed to write CAN signal %s: %s", signal.name,
 					 esp_err_to_name(err));

--- a/grafana/provisioning/datasources/influxdb.yaml
+++ b/grafana/provisioning/datasources/influxdb.yaml
@@ -1,0 +1,17 @@
+apiVersion: 1
+
+prune: true
+
+datasources:
+  - name: InfluxDB
+    type: influxdb
+    uid: influxdb-datasource
+    url: http://influxdb:8086
+    access: proxy
+    jsonData:
+      version: Flux
+      organization: $INFLUXDB_INIT_ORG
+      defaultBucket: $INFLUXDB_INIT_BUCKET
+      tlsSkipVerify: true
+    secureJsonData:
+      token: $INFLUXDB_TOKEN


### PR DESCRIPTION
## Summary

- Add historical InfluxDB panels alongside live MQTT panels for each CAN signal.
- Provision InfluxDB, Grafana datasource configuration, credentials, and persistent volumes in Docker Compose.
- Add InfluxDB Flux query generation and dashboard coverage tests.

## Testing

- Not run (not requested).