### PR TITLE
feat: add stable Grafana telemetry dashboards and alert provisioning

### DIFF
--- a/config.dbc
+++ b/config.dbc
@@ -22,13 +22,13 @@ BO_ 258 VehicleDynamics: 8 ECU
     SG_ SteeringAngle : 16|16@1- (0.1,0) [-3276.8|3276.7] "deg" DASH
     SG_ BrakePressure : 32|12@1+ (0.1,0) [0|400] "bar" DASH
 
-CM_ SG_ 256 EngineSpeed "vera:mqtt-topic=vehicle/engine/speed";
-CM_ SG_ 256 ThrottlePosition "vera:mqtt-topic=vehicle/engine/throttle";
-CM_ SG_ 256 CoolantTemperature "vera:mqtt-topic=vehicle/engine/coolant";
-CM_ SG_ 256 OilPressure "vera:mqtt-topic=vehicle/engine/oil-pressure";
-CM_ SG_ 257 BatteryVoltage "vera:mqtt-topic=vehicle/battery/voltage";
-CM_ SG_ 257 BatteryCurrent "vera:mqtt-topic=vehicle/battery/current";
-CM_ SG_ 257 BatteryTemperature "vera:mqtt-topic=vehicle/battery/temperature";
-CM_ SG_ 258 VehicleSpeed "vera:mqtt-topic=vehicle/dynamics/speed";
-CM_ SG_ 258 SteeringAngle "vera:mqtt-topic=vehicle/dynamics/steering";
-CM_ SG_ 258 BrakePressure "vera:mqtt-topic=vehicle/dynamics/brake";
+CM_ SG_ 256 EngineSpeed "vera:mqtt-topic=data/engine/speed";
+CM_ SG_ 256 ThrottlePosition "vera:mqtt-topic=data/engine/throttle";
+CM_ SG_ 256 CoolantTemperature "vera:mqtt-topic=data/engine/coolant";
+CM_ SG_ 256 OilPressure "vera:mqtt-topic=data/engine/oil-pressure";
+CM_ SG_ 257 BatteryVoltage "vera:mqtt-topic=data/battery/voltage";
+CM_ SG_ 257 BatteryCurrent "vera:mqtt-topic=data/battery/current";
+CM_ SG_ 257 BatteryTemperature "vera:mqtt-topic=data/battery/temperature";
+CM_ SG_ 258 VehicleSpeed "vera:mqtt-topic=data/dynamics/speed";
+CM_ SG_ 258 SteeringAngle "vera:mqtt-topic=data/dynamics/steering";
+CM_ SG_ 258 BrakePressure "vera:mqtt-topic=data/dynamics/brake";

--- a/config/alerting.go
+++ b/config/alerting.go
@@ -1,0 +1,403 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	alertDatasourceUID       = "influxdb-datasource"
+	alertDatasourceType      = "influxdb"
+	alertExpressionUID       = "__expr__"
+	alertEvaluationInterval  = "10s"
+	alertFolder              = "Ephoros Telemetry"
+	alertGroupName           = "Ephoros signal alerts"
+	alertDefaultLookbackSecs = 300
+)
+
+// AlertSignal is the dashboard-independent input used to provision alerts for
+// one telemetry topic. Nil threshold and staleness fields are not provisioned.
+// DashboardUID and PanelID are optional, but must be provided together.
+type AlertSignal struct {
+	Topic string
+
+	WarningLow   *float64
+	WarningHigh  *float64
+	CriticalLow  *float64
+	CriticalHigh *float64
+
+	StaleAfterSeconds *int
+	DashboardUID      string
+	PanelID           int
+}
+
+type alertProvisioning struct {
+	APIVersion int          `json:"apiVersion"`
+	Groups     []alertGroup `json:"groups"`
+}
+
+type alertGroup struct {
+	OrgID    int         `json:"orgId"`
+	Name     string      `json:"name"`
+	Folder   string      `json:"folder"`
+	Interval string      `json:"interval"`
+	Rules    []alertRule `json:"rules"`
+}
+
+type alertRule struct {
+	UID          string            `json:"uid"`
+	Title        string            `json:"title"`
+	Condition    string            `json:"condition"`
+	Data         []alertQuery      `json:"data"`
+	DashboardUID string            `json:"dashboardUid,omitempty"`
+	PanelID      int               `json:"panelId,omitempty"`
+	NoDataState  string            `json:"noDataState"`
+	ExecErrState string            `json:"execErrState"`
+	For          string            `json:"for"`
+	Annotations  map[string]string `json:"annotations"`
+	Labels       map[string]string `json:"labels"`
+	IsPaused     bool              `json:"isPaused"`
+}
+
+type alertQuery struct {
+	RefID             string                 `json:"refId"`
+	QueryType         string                 `json:"queryType"`
+	RelativeTimeRange alertRelativeTimeRange `json:"relativeTimeRange"`
+	DatasourceUID     string                 `json:"datasourceUid"`
+	Model             any                    `json:"model"`
+}
+
+type alertRelativeTimeRange struct {
+	From int `json:"from"`
+	To   int `json:"to"`
+}
+
+type influxAlertModel struct {
+	Datasource    alertDatasource `json:"datasource"`
+	Query         string          `json:"query"`
+	RawQuery      bool            `json:"rawQuery"`
+	ResultFormat  string          `json:"resultFormat"`
+	Hide          bool            `json:"hide"`
+	IntervalMS    int             `json:"intervalMs"`
+	MaxDataPoints int             `json:"maxDataPoints"`
+	RefID         string          `json:"refId"`
+}
+
+type expressionAlertModel struct {
+	Datasource    alertDatasource `json:"datasource"`
+	Expression    string          `json:"expression"`
+	Hide          bool            `json:"hide"`
+	IntervalMS    int             `json:"intervalMs"`
+	MaxDataPoints int             `json:"maxDataPoints"`
+	Reducer       string          `json:"reducer,omitempty"`
+	RefID         string          `json:"refId"`
+	Type          string          `json:"type"`
+}
+
+type alertDatasource struct {
+	Type string `json:"type"`
+	UID  string `json:"uid"`
+}
+
+// WriteAlertProvisioning writes Grafana file-provisioning JSON to path. The
+// caller should place that file under Grafana's provisioning/alerting folder.
+func WriteAlertProvisioning(path string, signals []AlertSignal) error {
+	if strings.TrimSpace(path) == "" {
+		return errors.New("alert provisioning path cannot be empty")
+	}
+
+	provisioning, err := buildAlertProvisioning(signals)
+	if err != nil {
+		return err
+	}
+
+	encoded, err := json.MarshalIndent(provisioning, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal alert provisioning: %w", err)
+	}
+	encoded = append(encoded, '\n')
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create alert provisioning directory: %w", err)
+	}
+	if err := os.WriteFile(path, encoded, 0o644); err != nil {
+		return fmt.Errorf("write alert provisioning: %w", err)
+	}
+	return nil
+}
+
+func buildAlertProvisioning(signals []AlertSignal) (alertProvisioning, error) {
+	sortedSignals := append([]AlertSignal(nil), signals...)
+	sort.Slice(sortedSignals, func(i, j int) bool {
+		return sortedSignals[i].Topic < sortedSignals[j].Topic
+	})
+
+	rules := make([]alertRule, 0, len(sortedSignals)*3)
+	seenTopics := make(map[string]struct{}, len(sortedSignals))
+	for _, signal := range sortedSignals {
+		if err := validateAlertSignal(signal); err != nil {
+			return alertProvisioning{}, err
+		}
+		if _, exists := seenTopics[signal.Topic]; exists {
+			return alertProvisioning{}, fmt.Errorf("duplicate alert topic %q", signal.Topic)
+		}
+		seenTopics[signal.Topic] = struct{}{}
+
+		lookbackSeconds := alertDefaultLookbackSecs
+		thresholdNoDataState := "NoData"
+		if signal.StaleAfterSeconds != nil {
+			lookbackSeconds = *signal.StaleAfterSeconds
+			thresholdNoDataState = "OK"
+		}
+
+		criticalExpression := buildCriticalExpression(signal)
+		if warningExpression := buildWarningExpression(signal); warningExpression != "" {
+			rules = append(rules, newThresholdAlertRule(
+				signal,
+				"warning",
+				warningExpression,
+				lookbackSeconds,
+				thresholdNoDataState,
+			))
+		}
+		if criticalExpression != "" {
+			rules = append(rules, newThresholdAlertRule(
+				signal,
+				"critical",
+				criticalExpression,
+				lookbackSeconds,
+				thresholdNoDataState,
+			))
+		}
+		if signal.StaleAfterSeconds != nil {
+			rules = append(rules, newStaleAlertRule(signal))
+		}
+	}
+
+	return alertProvisioning{
+		APIVersion: 1,
+		Groups: []alertGroup{{
+			OrgID:    1,
+			Name:     alertGroupName,
+			Folder:   alertFolder,
+			Interval: alertEvaluationInterval,
+			Rules:    rules,
+		}},
+	}, nil
+}
+
+func validateAlertSignal(signal AlertSignal) error {
+	if strings.TrimSpace(signal.Topic) == "" {
+		return errors.New("alert topic cannot be empty")
+	}
+	if (signal.DashboardUID == "") != (signal.PanelID == 0) {
+		return fmt.Errorf("dashboard UID and panel ID must be provided together for topic %q", signal.Topic)
+	}
+	if signal.PanelID < 0 {
+		return fmt.Errorf("panel ID must be positive for topic %q", signal.Topic)
+	}
+	if signal.StaleAfterSeconds != nil && *signal.StaleAfterSeconds <= 0 {
+		return fmt.Errorf("stale-after seconds must be positive for topic %q", signal.Topic)
+	}
+
+	orderedThresholds := []struct {
+		name  string
+		value *float64
+	}{
+		{"critical low", signal.CriticalLow},
+		{"warning low", signal.WarningLow},
+		{"warning high", signal.WarningHigh},
+		{"critical high", signal.CriticalHigh},
+	}
+	var previous *struct {
+		name  string
+		value float64
+	}
+	for _, threshold := range orderedThresholds {
+		if threshold.value == nil {
+			continue
+		}
+		if math.IsNaN(*threshold.value) || math.IsInf(*threshold.value, 0) {
+			return fmt.Errorf("%s threshold must be finite for topic %q", threshold.name, signal.Topic)
+		}
+		if previous != nil && previous.value >= *threshold.value {
+			return fmt.Errorf(
+				"%s threshold must be less than %s threshold for topic %q",
+				previous.name,
+				threshold.name,
+				signal.Topic,
+			)
+		}
+		previous = &struct {
+			name  string
+			value float64
+		}{threshold.name, *threshold.value}
+	}
+	return nil
+}
+
+func newThresholdAlertRule(
+	signal AlertSignal,
+	severity string,
+	expression string,
+	lookbackSeconds int,
+	noDataState string,
+) alertRule {
+	rule := newAlertRule(signal, severity, severity)
+	rule.NoDataState = noDataState
+	rule.Data = alertRuleData(signal.Topic, expression, lookbackSeconds)
+	rule.Annotations = map[string]string{
+		"summary":     fmt.Sprintf("%s telemetry is outside its %s operating band", signal.Topic, severity),
+		"description": fmt.Sprintf("The latest stored value for %s breached its configured %s threshold.", signal.Topic, severity),
+	}
+	return rule
+}
+
+func newStaleAlertRule(signal AlertSignal) alertRule {
+	rule := newAlertRule(signal, "stale", "warning")
+	rule.NoDataState = "Alerting"
+	rule.Data = alertRuleData(signal.Topic, "is_number($B) == 0", *signal.StaleAfterSeconds)
+	rule.Annotations = map[string]string{
+		"summary":     fmt.Sprintf("%s telemetry is stale", signal.Topic),
+		"description": fmt.Sprintf("InfluxDB has no numeric sample for %s within the last %d seconds.", signal.Topic, *signal.StaleAfterSeconds),
+	}
+	return rule
+}
+
+func newAlertRule(signal AlertSignal, kind string, severity string) alertRule {
+	return alertRule{
+		UID:          alertRuleUID(signal.Topic, kind),
+		Title:        fmt.Sprintf("%s %s", signal.Topic, kind),
+		Condition:    "C",
+		DashboardUID: signal.DashboardUID,
+		PanelID:      signal.PanelID,
+		NoDataState:  "NoData",
+		ExecErrState: "Error",
+		For:          "0s",
+		Labels: map[string]string{
+			"severity": severity,
+			"topic":    signal.Topic,
+		},
+		IsPaused: false,
+	}
+}
+
+func alertRuleData(topic string, condition string, lookbackSeconds int) []alertQuery {
+	zeroRange := alertRelativeTimeRange{From: 0, To: 0}
+	return []alertQuery{
+		{
+			RefID:             "A",
+			QueryType:         "",
+			RelativeTimeRange: alertRelativeTimeRange{From: lookbackSeconds, To: 0},
+			DatasourceUID:     alertDatasourceUID,
+			Model: influxAlertModel{
+				Datasource:    alertDatasource{Type: alertDatasourceType, UID: alertDatasourceUID},
+				Query:         alertInfluxQuery(topic),
+				RawQuery:      true,
+				ResultFormat:  "time_series",
+				Hide:          false,
+				IntervalMS:    1_000,
+				MaxDataPoints: 43_200,
+				RefID:         "A",
+			},
+		},
+		{
+			RefID:             "B",
+			QueryType:         "",
+			RelativeTimeRange: zeroRange,
+			DatasourceUID:     alertExpressionUID,
+			Model: expressionAlertModel{
+				Datasource:    alertDatasource{Type: alertExpressionUID, UID: alertExpressionUID},
+				Expression:    "A",
+				Hide:          false,
+				IntervalMS:    1_000,
+				MaxDataPoints: 43_200,
+				Reducer:       "last",
+				RefID:         "B",
+				Type:          "reduce",
+			},
+		},
+		{
+			RefID:             "C",
+			QueryType:         "",
+			RelativeTimeRange: zeroRange,
+			DatasourceUID:     alertExpressionUID,
+			Model: expressionAlertModel{
+				Datasource:    alertDatasource{Type: alertExpressionUID, UID: alertExpressionUID},
+				Expression:    condition,
+				Hide:          false,
+				IntervalMS:    1_000,
+				MaxDataPoints: 43_200,
+				RefID:         "C",
+				Type:          "math",
+			},
+		},
+	}
+}
+
+func alertInfluxQuery(topic string) string {
+	return fmt.Sprintf(`from(bucket: %q)
+  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+  |> filter(fn: (r) => r["_measurement"] == "can_signal")
+  |> filter(fn: (r) => r["_field"] == "value")
+  |> filter(fn: (r) => r["topic"] == %q)
+  |> last()`, influxDBBucket(), topic)
+}
+
+func buildCriticalExpression(signal AlertSignal) string {
+	conditions := make([]string, 0, 2)
+	if signal.CriticalLow != nil {
+		conditions = append(conditions, "$B <= "+formatThreshold(*signal.CriticalLow))
+	}
+	if signal.CriticalHigh != nil {
+		conditions = append(conditions, "$B >= "+formatThreshold(*signal.CriticalHigh))
+	}
+	return joinAlertConditions(conditions, " || ")
+}
+
+func buildWarningExpression(signal AlertSignal) string {
+	conditions := make([]string, 0, 2)
+	if signal.WarningLow != nil {
+		low := "$B <= " + formatThreshold(*signal.WarningLow)
+		if signal.CriticalLow != nil {
+			low = "(" + low + " && $B > " + formatThreshold(*signal.CriticalLow) + ")"
+		}
+		conditions = append(conditions, low)
+	}
+	if signal.WarningHigh != nil {
+		high := "$B >= " + formatThreshold(*signal.WarningHigh)
+		if signal.CriticalHigh != nil {
+			high = "(" + high + " && $B < " + formatThreshold(*signal.CriticalHigh) + ")"
+		}
+		conditions = append(conditions, high)
+	}
+	return joinAlertConditions(conditions, " || ")
+}
+
+func joinAlertConditions(conditions []string, separator string) string {
+	if len(conditions) == 0 {
+		return ""
+	}
+	if len(conditions) == 1 {
+		return conditions[0]
+	}
+	return "(" + strings.Join(conditions, separator) + ")"
+}
+
+func formatThreshold(value float64) string {
+	return strconv.FormatFloat(value, 'g', -1, 64)
+}
+
+func alertRuleUID(topic string, kind string) string {
+	digest := sha256.Sum256([]byte(topic + "\x00" + kind))
+	return "ephoros-" + kind + "-" + hex.EncodeToString(digest[:8])
+}

--- a/config/alerting_test.go
+++ b/config/alerting_test.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestBuildAlertProvisioningCreatesInfluxThresholdBands(t *testing.T) {
+	warningLow := 600.0
+	warningHigh := 6_500.0
+	criticalLow := 300.0
+	criticalHigh := 7_000.0
+	staleSeconds := 30
+
+	provisioning, err := buildAlertProvisioning([]AlertSignal{{
+		Topic:             "data/powertrain/engine-speed",
+		WarningLow:        &warningLow,
+		WarningHigh:       &warningHigh,
+		CriticalLow:       &criticalLow,
+		CriticalHigh:      &criticalHigh,
+		StaleAfterSeconds: &staleSeconds,
+		DashboardUID:      "generated-telemetry",
+		PanelID:           12,
+	}})
+	if err != nil {
+		t.Fatalf("build alert provisioning: %v", err)
+	}
+
+	if provisioning.APIVersion != 1 {
+		t.Fatalf("apiVersion = %d, want 1", provisioning.APIVersion)
+	}
+	if len(provisioning.Groups) != 1 {
+		t.Fatalf("groups = %d, want 1", len(provisioning.Groups))
+	}
+	group := provisioning.Groups[0]
+	if group.Interval != "10s" {
+		t.Errorf("evaluation interval = %q, want 10s", group.Interval)
+	}
+	if len(group.Rules) != 3 {
+		t.Fatalf("rules = %d, want warning, critical, and stale", len(group.Rules))
+	}
+
+	warning := group.Rules[0]
+	if warning.Labels["severity"] != "warning" || warning.Labels["topic"] != "data/powertrain/engine-speed" {
+		t.Errorf("warning labels = %#v", warning.Labels)
+	}
+	if warning.DashboardUID != "generated-telemetry" || warning.PanelID != 12 {
+		t.Errorf("warning dashboard link = %q/%d", warning.DashboardUID, warning.PanelID)
+	}
+	if warning.NoDataState != "OK" {
+		t.Errorf("warning no-data state = %q, want OK when a stale rule exists", warning.NoDataState)
+	}
+	assertAlertData(t, warning, 30, "(($B <= 600 && $B > 300) || ($B >= 6500 && $B < 7000))")
+
+	critical := group.Rules[1]
+	if critical.Labels["severity"] != "critical" {
+		t.Errorf("critical severity = %q", critical.Labels["severity"])
+	}
+	assertAlertData(t, critical, 30, "($B <= 300 || $B >= 7000)")
+
+	stale := group.Rules[2]
+	if stale.Labels["severity"] != "warning" {
+		t.Errorf("stale severity = %q", stale.Labels["severity"])
+	}
+	if stale.NoDataState != "Alerting" {
+		t.Errorf("stale no-data state = %q, want Alerting", stale.NoDataState)
+	}
+	assertAlertData(t, stale, 30, "is_number($B) == 0")
+}
+
+func TestBuildAlertProvisioningUsesNoDataStateWithoutStalePolicy(t *testing.T) {
+	warningHigh := 80.0
+	provisioning, err := buildAlertProvisioning([]AlertSignal{{
+		Topic:       "data/electrical/battery-temperature",
+		WarningHigh: &warningHigh,
+	}})
+	if err != nil {
+		t.Fatalf("build alert provisioning: %v", err)
+	}
+
+	rule := provisioning.Groups[0].Rules[0]
+	if rule.NoDataState != "NoData" {
+		t.Errorf("no-data state = %q, want NoData", rule.NoDataState)
+	}
+	assertAlertData(t, rule, alertDefaultLookbackSecs, "$B >= 80")
+}
+
+func TestBuildAlertProvisioningIsDeterministic(t *testing.T) {
+	low := 1.0
+	high := 2.0
+	first := []AlertSignal{
+		{Topic: "data/zeta/value", CriticalHigh: &high},
+		{Topic: "data/alpha/value", WarningLow: &low},
+	}
+	second := []AlertSignal{first[1], first[0]}
+
+	left, err := buildAlertProvisioning(first)
+	if err != nil {
+		t.Fatalf("build first provisioning: %v", err)
+	}
+	right, err := buildAlertProvisioning(second)
+	if err != nil {
+		t.Fatalf("build second provisioning: %v", err)
+	}
+	if !reflect.DeepEqual(left, right) {
+		t.Fatalf("provisioning differs when input order changes\nleft: %#v\nright: %#v", left, right)
+	}
+
+	rules := left.Groups[0].Rules
+	if rules[0].Labels["topic"] != "data/alpha/value" || rules[1].Labels["topic"] != "data/zeta/value" {
+		t.Errorf("rules are not sorted by topic: %#v", rules)
+	}
+	for _, rule := range rules {
+		if len(rule.UID) > 40 {
+			t.Errorf("rule UID %q exceeds Grafana's 40-character limit", rule.UID)
+		}
+	}
+}
+
+func TestWriteAlertProvisioningWritesValidJSON(t *testing.T) {
+	criticalHigh := 100.0
+	path := filepath.Join(t.TempDir(), "nested", "alerts.json")
+	if err := WriteAlertProvisioning(path, []AlertSignal{{
+		Topic:        "data/electrical/voltage",
+		CriticalHigh: &criticalHigh,
+	}}); err != nil {
+		t.Fatalf("write alert provisioning: %v", err)
+	}
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read alert provisioning: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(contents, &decoded); err != nil {
+		t.Fatalf("generated provisioning is not JSON: %v", err)
+	}
+	if !strings.HasSuffix(string(contents), "\n") {
+		t.Error("generated provisioning should end with a newline")
+	}
+	if strings.Contains(string(contents), "mqtt-datasource") {
+		t.Error("generated alert provisioning must not query the MQTT datasource")
+	}
+	if !strings.Contains(string(contents), `"datasourceUid": "influxdb-datasource"`) {
+		t.Error("generated alert provisioning does not query InfluxDB")
+	}
+}
+
+func TestBuildAlertProvisioningRejectsInvalidSignals(t *testing.T) {
+	zero := 0
+	nan := math.NaN()
+	criticalLow := 300.0
+	warningLow := 200.0
+	high := 100.0
+
+	tests := []struct {
+		name    string
+		signals []AlertSignal
+		want    string
+	}{
+		{name: "empty topic", signals: []AlertSignal{{}}, want: "topic cannot be empty"},
+		{
+			name: "duplicate topic",
+			signals: []AlertSignal{
+				{Topic: "data/a/value", WarningHigh: &high},
+				{Topic: "data/a/value", CriticalHigh: &high},
+			},
+			want: "duplicate alert topic",
+		},
+		{
+			name:    "partial dashboard link",
+			signals: []AlertSignal{{Topic: "data/a/value", DashboardUID: "dashboard"}},
+			want:    "must be provided together",
+		},
+		{
+			name:    "non-positive stale interval",
+			signals: []AlertSignal{{Topic: "data/a/value", StaleAfterSeconds: &zero}},
+			want:    "must be positive",
+		},
+		{
+			name:    "non-finite threshold",
+			signals: []AlertSignal{{Topic: "data/a/value", CriticalHigh: &nan}},
+			want:    "must be finite",
+		},
+		{
+			name: "misordered thresholds",
+			signals: []AlertSignal{{
+				Topic:       "data/a/value",
+				CriticalLow: &criticalLow,
+				WarningLow:  &warningLow,
+			}},
+			want: "critical low threshold must be less than warning low threshold",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := buildAlertProvisioning(test.signals)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func assertAlertData(t *testing.T, rule alertRule, wantLookback int, wantCondition string) {
+	t.Helper()
+	if len(rule.Data) != 3 {
+		t.Fatalf("data stages = %d, want 3", len(rule.Data))
+	}
+
+	query := rule.Data[0]
+	if query.DatasourceUID != alertDatasourceUID {
+		t.Errorf("query datasource = %q, want %q", query.DatasourceUID, alertDatasourceUID)
+	}
+	if query.RelativeTimeRange.From != wantLookback || query.RelativeTimeRange.To != 0 {
+		t.Errorf("query time range = %#v, want from=%d to=0", query.RelativeTimeRange, wantLookback)
+	}
+	model, ok := query.Model.(influxAlertModel)
+	if !ok {
+		t.Fatalf("query model type = %T, want influxAlertModel", query.Model)
+	}
+	for _, expected := range []string{
+		`from(bucket: "telemetry")`,
+		`r["_measurement"] == "can_signal"`,
+		`r["_field"] == "value"`,
+		`r["topic"] == "data/`,
+		`|> last()`,
+	} {
+		if !strings.Contains(model.Query, expected) {
+			t.Errorf("Influx query does not contain %q:\n%s", expected, model.Query)
+		}
+	}
+
+	reduce, ok := rule.Data[1].Model.(expressionAlertModel)
+	if !ok || reduce.Type != "reduce" || reduce.Reducer != "last" || reduce.Expression != "A" {
+		t.Errorf("reduce model = %#v", rule.Data[1].Model)
+	}
+	condition, ok := rule.Data[2].Model.(expressionAlertModel)
+	if !ok || condition.Type != "math" || condition.Expression != wantCondition {
+		t.Errorf("condition model = %#v, want expression %q", rule.Data[2].Model, wantCondition)
+	}
+	if rule.Condition != "C" {
+		t.Errorf("rule condition = %q, want C", rule.Condition)
+	}
+}

--- a/config/dashboards.go
+++ b/config/dashboards.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/ApexCorse/vera"
 	"github.com/grafana/grafana-foundation-sdk/go/cog"
@@ -14,8 +19,11 @@ import (
 )
 
 const (
-	topicPrefix = "data/"
-	providers   = `apiVersion: 1
+	topicPrefix       = "data/"
+	telemetryUID      = "generated-telemetry"
+	telemetryTitle    = "Vehicle Telemetry"
+	detailTitleSuffix = " Telemetry Detail"
+	providers         = `apiVersion: 1
 
 providers:
   - name: 'MQTT dashboards'
@@ -39,86 +47,265 @@ var (
 	}
 )
 
-// parseSignalTopicHierarchy groups DBC signal topics by their first two topic levels.
-// Topics are expected to follow the pattern: data/firstLevel/secondLevel.
-func parseSignalTopicHierarchy(signalTopics []vera.SignalTopic) (map[string]map[string][]vera.SignalTopic, error) {
-	topicsMap := make(map[string]map[string][]vera.SignalTopic)
+type topicSection struct {
+	name    string
+	signals []topicSignal
+}
+
+type topicSignal struct {
+	label string
+	topic string
+}
+
+// alertListOptions mirrors Grafana's native alertlist panel options. It is
+// local because the Foundation SDK does not currently generate this panel.
+type alertListOptions struct {
+	ViewMode                 string               `json:"viewMode"`
+	GroupMode                string               `json:"groupMode"`
+	MaxItems                 int                  `json:"maxItems"`
+	SortOrder                int                  `json:"sortOrder"`
+	DashboardAlerts          bool                 `json:"dashboardAlerts"`
+	AlertName                string               `json:"alertName"`
+	AlertInstanceLabelFilter string               `json:"alertInstanceLabelFilter"`
+	ShowInactiveAlerts       bool                 `json:"showInactiveAlerts"`
+	StateFilter              alertListStateFilter `json:"stateFilter"`
+}
+
+type alertListStateFilter struct {
+	Firing     bool `json:"firing"`
+	Pending    bool `json:"pending"`
+	Recovering bool `json:"recovering"`
+	NoData     bool `json:"noData"`
+	Normal     bool `json:"normal"`
+	Error      bool `json:"error"`
+}
+
+// parseSignalTopicHierarchy groups topics into dashboard sections. A valid topic
+// has a section and signal path after the required data/ prefix.
+func parseSignalTopicHierarchy(signalTopics []vera.SignalTopic) ([]topicSection, error) {
+	sectionsByName := make(map[string][]topicSignal)
+	seenTopics := make(map[string]struct{}, len(signalTopics))
 
 	for _, signalTopic := range signalTopics {
 		topic := signalTopic.Topic
 		if !strings.HasPrefix(topic, topicPrefix) {
-			return nil, fmt.Errorf("each topic must start with '%s': %s", topicPrefix, topic)
+			return nil, fmt.Errorf("each topic must start with %q: %s", topicPrefix, topic)
 		}
 
-		strippedTopic := strings.TrimPrefix(topic, topicPrefix)
-		topicParts := strings.Split(strippedTopic, "/")
-
-		if len(topicParts) < 2 {
-			return nil, fmt.Errorf("topic must have at least 2 levels after '%s': %s", topicPrefix, topic)
+		parts := strings.Split(strings.TrimPrefix(topic, topicPrefix), "/")
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("topic must have a section and signal after %q: %s", topicPrefix, topic)
 		}
-
-		firstLevel := topicParts[0]
-		secondLevel := topicParts[1]
-
-		if firstLevel == "" || secondLevel == "" {
-			return nil, fmt.Errorf("topic levels cannot be empty: %s", topic)
+		for _, part := range parts {
+			if part == "" {
+				return nil, fmt.Errorf("topic levels cannot be empty: %s", topic)
+			}
 		}
-
-		if _, exists := topicsMap[firstLevel]; !exists {
-			topicsMap[firstLevel] = make(map[string][]vera.SignalTopic)
+		if _, exists := seenTopics[topic]; exists {
+			return nil, fmt.Errorf("duplicate topic: %s", topic)
 		}
+		seenTopics[topic] = struct{}{}
 
-		topicsMap[firstLevel][secondLevel] = append(topicsMap[firstLevel][secondLevel], signalTopic)
+		section := parts[0]
+		sectionsByName[section] = append(sectionsByName[section], topicSignal{
+			label: humanizeTopicPath(parts[1:]),
+			topic: topic,
+		})
 	}
 
-	return topicsMap, nil
+	sections := make([]topicSection, 0, len(sectionsByName))
+	for name, signals := range sectionsByName {
+		sort.Slice(signals, func(i, j int) bool {
+			if signals[i].label == signals[j].label {
+				return signals[i].topic < signals[j].topic
+			}
+			return signals[i].label < signals[j].label
+		})
+		sections = append(sections, topicSection{name: humanizeTopicSegment(name), signals: signals})
+	}
+	sort.Slice(sections, func(i, j int) bool { return sections[i].name < sections[j].name })
+
+	return sections, nil
 }
 
-// buildDashboardForLevel creates live MQTT and historical InfluxDB panels for every signal.
-func buildDashboardForLevel(firstLevel string, secondLevels map[string][]vera.SignalTopic) (dashboard.Dashboard, error) {
-	dashboardBuilder := dashboard.NewDashboardBuilder(firstLevel).
-		Uid(fmt.Sprintf("generated-%s", firstLevel)).
-		Refresh("1m").
-		Time("now-1m", "now")
+func humanizeTopicPath(parts []string) string {
+	labels := make([]string, len(parts))
+	for i, part := range parts {
+		labels[i] = humanizeTopicSegment(part)
+	}
+	return strings.Join(labels, " / ")
+}
 
-	for secondLevel, signalTopics := range secondLevels {
-		row := dashboard.NewRowBuilder(secondLevel)
+func humanizeTopicSegment(segment string) string {
+	words := strings.FieldsFunc(segment, func(r rune) bool {
+		return r == '-' || r == '_'
+	})
+	for i, word := range words {
+		words[i] = capitalize(word)
+	}
+	return strings.Join(words, " ")
+}
 
-		for _, signalTopic := range signalTopics {
-			row = row.WithPanel(
+func capitalize(value string) string {
+	for index, r := range value {
+		return string(unicode.ToUpper(r)) + value[index+len(string(r)):]
+	}
+	return value
+}
+
+// stablePanelID keeps provisioned alert links valid across regenerations. The
+// kind byte separates the live and historical panels for the same topic.
+func stablePanelID(topic string, kind byte) uint32 {
+	digest := sha256.Sum256(append([]byte{kind, 0}, []byte(topic)...))
+	id := binary.BigEndian.Uint32(digest[:4]) & 0x7fffffff
+	if id == 0 {
+		return 1
+	}
+	return id
+}
+
+// detailDashboardKey is used for both the provisioned filename and dashboard
+// UID. It intentionally derives from the complete topic rather than its label,
+// so renaming a display label never invalidates existing drill-down URLs. The
+// 80-bit digest keeps the UID within Grafana's 40-character limit.
+func detailDashboardKey(topic string) string {
+	digest := sha256.Sum256([]byte(topic))
+	return "generated-signal-" + hex.EncodeToString(digest[:10])
+}
+
+func detailDashboardURL(topic string) string {
+	return "/d/" + detailDashboardKey(topic) + "?from=${__from}&to=${__to}"
+}
+
+func detailDashboardLink(topic string) *dashboard.DashboardLinkBuilder {
+	return dashboard.NewDashboardLinkBuilder("Open detail").
+		Type(dashboard.DashboardLinkTypeLink).
+		Url(detailDashboardURL(topic)).
+		KeepTime(true)
+}
+
+func alertListPanel() *dashboard.PanelBuilder {
+	return dashboard.NewPanelBuilder().
+		Type("alertlist").
+		Id(stablePanelID(telemetryUID, 'a')).
+		Title("Active Alerts").
+		Description("Firing, pending, no-data, and error states for telemetry alerts linked to this dashboard.").
+		Span(24).
+		Height(5).
+		Options(alertListOptions{
+			ViewMode:                 "list",
+			GroupMode:                "default",
+			MaxItems:                 20,
+			SortOrder:                3, // Grafana's Importance sort order.
+			DashboardAlerts:          true,
+			AlertName:                "",
+			AlertInstanceLabelFilter: "",
+			ShowInactiveAlerts:       false,
+			StateFilter: alertListStateFilter{
+				Firing:     true,
+				Pending:    true,
+				Recovering: false,
+				NoData:     true,
+				Normal:     false,
+				Error:      true,
+			},
+		})
+}
+
+// buildTelemetryDashboard creates one stable topic-derived dashboard. Panels
+// follow each expanded row at dashboard level because Grafana only preserves
+// panels nested inside collapsed rows.
+func buildTelemetryDashboard(sections []topicSection) (dashboard.Dashboard, error) {
+	builder := dashboard.NewDashboardBuilder(telemetryTitle).
+		Uid(telemetryUID).
+		Refresh("1s").
+		LiveNow(true).
+		Time("now-15m", "now").
+		WithPanel(alertListPanel())
+
+	for _, section := range sections {
+		builder = builder.WithRow(dashboard.NewRowBuilder(section.name).Collapsed(false))
+		for _, signal := range section.signals {
+			builder = builder.WithPanel(
 				stat.NewPanelBuilder().
-					Title(signalTopic.Topic + " (live)").
-					GraphMode(common.BigValueGraphModeNone).
+					Id(stablePanelID(signal.topic, 'l')).
+					Title(signal.label + " (live)").
+					Span(12).
+					GraphMode(common.BigValueGraphModeArea).
+					NoValue("No data").
 					Datasource(dataSourceRef).
-					WithTarget(NewMQTTQueryBuilder(signalTopic.Topic)),
+					DataLinks([]cog.Builder[dashboard.DashboardLink]{detailDashboardLink(signal.topic)}).
+					WithTarget(NewMQTTQueryBuilder(signal.topic)),
 			).WithPanel(
 				timeseries.NewPanelBuilder().
-					Title(signalTopic.Topic + " (history)").
+					Id(stablePanelID(signal.topic, 'h')).
+					Title(signal.label + " (history)").
+					Span(12).
 					Datasource(influxDBDataSourceRef).
-					WithTarget(NewInfluxDBQueryBuilder(signalTopic.Topic)),
+					DataLinks([]cog.Builder[dashboard.DashboardLink]{detailDashboardLink(signal.topic)}).
+					WithTarget(NewInfluxDBQueryBuilder(signal.topic)),
 			)
 		}
-
-		dashboardBuilder = dashboardBuilder.WithRow(row)
 	}
 
-	return dashboardBuilder.Build()
+	return builder.Build()
 }
 
-// createDashboardsWithSignalTopics generates Grafana dashboards from DBC signal-topic mappings.
+// buildSignalDetailDashboard creates a dedicated, literal-topic dashboard.
+// MQTT targets do not support dashboard template variable interpolation, so a
+// dashboard per topic preserves the exact subscription and query filter.
+func buildSignalDetailDashboard(signal topicSignal) (dashboard.Dashboard, error) {
+	return dashboard.NewDashboardBuilder(signal.label+detailTitleSuffix).
+		Uid(detailDashboardKey(signal.topic)).
+		Description("MQTT topic: "+signal.topic).
+		Refresh("1s").
+		LiveNow(true).
+		Time("now-24h", "now").
+		WithPanel(
+			stat.NewPanelBuilder().
+				Id(stablePanelID(signal.topic, 'd')).
+				Title(signal.label + " (live)").
+				Description("Latest value from MQTT topic: " + signal.topic).
+				Span(24).
+				GraphMode(common.BigValueGraphModeArea).
+				NoValue("No data").
+				Datasource(dataSourceRef).
+				WithTarget(NewMQTTQueryBuilder(signal.topic)),
+		).
+		WithPanel(
+			timeseries.NewPanelBuilder().
+				Id(stablePanelID(signal.topic, 'D')).
+				Title(signal.label + " (history)").
+				Description("24-hour InfluxDB history for MQTT topic: " + signal.topic).
+				Span(24).
+				Datasource(influxDBDataSourceRef).
+				WithTarget(NewInfluxDBQueryBuilder(signal.topic)),
+		).
+		Build()
+}
+
+// createDashboardsWithSignalTopics generates a stable overview and one
+// deterministic drill-down dashboard per DBC signal-topic mapping.
 func createDashboardsWithSignalTopics(signalTopics []vera.SignalTopic) (map[string]dashboard.Dashboard, error) {
-	topicsMap, err := parseSignalTopicHierarchy(signalTopics)
+	sections, err := parseSignalTopicHierarchy(signalTopics)
 	if err != nil {
 		return nil, err
 	}
 
-	dashboards := make(map[string]dashboard.Dashboard)
-	for firstLevel, secondLevels := range topicsMap {
-		dashboard, err := buildDashboardForLevel(firstLevel, secondLevels)
-		if err != nil {
-			return nil, fmt.Errorf("failed to build dashboard for '%s': %w", firstLevel, err)
+	telemetryDashboard, err := buildTelemetryDashboard(sections)
+	if err != nil {
+		return nil, fmt.Errorf("build telemetry dashboard: %w", err)
+	}
+
+	dashboards := map[string]dashboard.Dashboard{"telemetry": telemetryDashboard}
+	for _, section := range sections {
+		for _, signal := range section.signals {
+			detailDashboard, err := buildSignalDetailDashboard(signal)
+			if err != nil {
+				return nil, fmt.Errorf("build detail dashboard for %q: %w", signal.topic, err)
+			}
+			dashboards[detailDashboardKey(signal.topic)] = detailDashboard
 		}
-		dashboards[firstLevel] = dashboard
 	}
 
 	return dashboards, nil

--- a/config/dashboards_test.go
+++ b/config/dashboards_test.go
@@ -8,30 +8,126 @@ import (
 	"github.com/ApexCorse/vera"
 )
 
-func TestBuildDashboardForLevelPairsLiveAndHistoricalPanels(t *testing.T) {
-	dashboard, err := buildDashboardForLevel("powertrain", map[string][]vera.SignalTopic{
-		"engine": {{Signal: "EngineSpeed", Topic: "data/powertrain/engine-speed"}},
+func TestCreateDashboardsWithSignalTopicsBuildsStableOverviewAndDetails(t *testing.T) {
+	dashboards, err := createDashboardsWithSignalTopics([]vera.SignalTopic{
+		{Signal: "OilPressure", Topic: "data/powertrain/engine/oil-pressure"},
+		{Signal: "StateOfCharge", Topic: "data/electrical/battery/state-of-charge"},
+		{Signal: "EngineSpeed", Topic: "data/powertrain/engine-speed"},
 	})
 	if err != nil {
-		t.Fatalf("build dashboard: %v", err)
+		t.Fatalf("create dashboards: %v", err)
+	}
+	if len(dashboards) != 4 {
+		t.Fatalf("dashboard count = %d, want 4", len(dashboards))
 	}
 
-	encoded, err := json.Marshal(dashboard)
+	telemetryDashboard, ok := dashboards["telemetry"]
+	if !ok {
+		t.Fatal("telemetry dashboard is missing")
+	}
+	encoded, err := json.Marshal(telemetryDashboard)
 	if err != nil {
 		t.Fatalf("marshal dashboard: %v", err)
 	}
-	json := string(encoded)
+	generated := string(encoded)
 
 	for _, expected := range []string{
-		"data/powertrain/engine-speed",
+		`"uid":"generated-telemetry"`,
+		`"refresh":"1s"`,
+		`"from":"now-15m"`,
+		`"type":"alertlist"`,
+		`"title":"Active Alerts"`,
+		`"viewMode":"list"`,
+		`"groupMode":"default"`,
+		`"sortOrder":3`,
+		`"dashboardAlerts":true`,
+		`"showInactiveAlerts":false`,
+		`"stateFilter":{"firing":true,"pending":true,"recovering":false,"noData":true,"normal":false,"error":true}`,
+		`"title":"Electrical"`,
+		`"title":"Powertrain"`,
+		`"title":"Battery / State Of Charge (live)"`,
+		`"title":"Engine / Oil Pressure (history)"`,
+		`"title":"Engine Speed (live)"`,
 		"grafana-mqtt-datasource",
-		`"graphMode":"none"`,
 		"influxdb-datasource",
-		`r[\"topic\"] == \"data/powertrain/engine-speed\"`,
+		"data/powertrain/engine/oil-pressure",
+		`"graphMode":"area"`,
+		`"noValue":"No data"`,
+		`"collapsed":false`,
+		`"title":"Open detail"`,
+		`from=${__from}\u0026to=${__to}`,
 	} {
-		if !strings.Contains(json, expected) {
+		if !strings.Contains(generated, expected) {
 			t.Errorf("generated dashboard does not contain %q", expected)
 		}
+	}
+	if strings.Index(generated, `"title":"Active Alerts"`) > strings.Index(generated, `"title":"Electrical"`) {
+		t.Error("alert list is not the first dashboard panel")
+	}
+
+	if strings.Index(generated, `"title":"Electrical"`) > strings.Index(generated, `"title":"Powertrain"`) {
+		t.Error("sections are not in alphabetical order")
+	}
+	if strings.Index(generated, `"title":"Engine / Oil Pressure (live)"`) > strings.Index(generated, `"title":"Engine Speed (live)"`) {
+		t.Error("signals are not in alphabetical order")
+	}
+
+	for _, topic := range []string{
+		"data/powertrain/engine/oil-pressure",
+		"data/electrical/battery/state-of-charge",
+		"data/powertrain/engine-speed",
+	} {
+		linkURL := strings.ReplaceAll(detailDashboardURL(topic), "&", `\u0026`)
+		if count := strings.Count(generated, linkURL); count != 2 {
+			t.Errorf("overview links to detail dashboard for %q %d times, want 2", topic, count)
+		}
+
+		key := detailDashboardKey(topic)
+		detailDashboard, ok := dashboards[key]
+		if !ok {
+			t.Errorf("detail dashboard for %q is missing", topic)
+			continue
+		}
+
+		detailJSON, err := json.Marshal(detailDashboard)
+		if err != nil {
+			t.Errorf("marshal detail dashboard for %q: %v", topic, err)
+			continue
+		}
+		generatedDetail := string(detailJSON)
+		for _, expected := range []string{
+			`"uid":"` + key + `"`,
+			`"refresh":"1s"`,
+			`"from":"now-24h"`,
+			topic,
+			"grafana-mqtt-datasource",
+			"influxdb-datasource",
+		} {
+			if !strings.Contains(generatedDetail, expected) {
+				t.Errorf("detail dashboard for %q does not contain %q", topic, expected)
+			}
+		}
+	}
+}
+
+func TestParseSignalTopicHierarchyRejectsInvalidTopics(t *testing.T) {
+	for _, topic := range []string{
+		"vehicle/powertrain/engine-speed",
+		"data/powertrain",
+		"data//engine-speed",
+		"data/powertrain/",
+		"data/powertrain/engine-speed",
+	} {
+		t.Run(topic, func(t *testing.T) {
+			topics := []vera.SignalTopic{{Topic: topic}}
+			if topic == "data/powertrain/engine-speed" {
+				topics = append(topics, vera.SignalTopic{Topic: topic})
+			}
+			_, err := parseSignalTopicHierarchy(topics)
+			if err == nil {
+				t.Errorf("parseSignalTopicHierarchy(%q) succeeded, want error", topic)
+			}
+		})
 	}
 }
 
@@ -47,5 +143,39 @@ func TestInfluxDBQueryUsesMQTTTopic(t *testing.T) {
 	}
 	if !strings.Contains(influxQuery.Query, `r["topic"] == "data/electrical/battery-voltage"`) {
 		t.Errorf("query does not filter by the MQTT topic: %s", influxQuery.Query)
+	}
+}
+
+func TestStablePanelIDSeparatesPanelKinds(t *testing.T) {
+	topic := "data/powertrain/engine-speed"
+	live := stablePanelID(topic, 'l')
+	history := stablePanelID(topic, 'h')
+	if live == 0 || history == 0 {
+		t.Fatal("panel IDs must be non-zero")
+	}
+	if live == history {
+		t.Fatalf("live and history panel IDs collide: %d", live)
+	}
+	if stablePanelID(topic, 'l') != live {
+		t.Fatal("panel ID is not deterministic")
+	}
+}
+
+func TestDetailDashboardKeyAndLinkAreStable(t *testing.T) {
+	topic := "data/powertrain/engine-speed"
+	key := detailDashboardKey(topic)
+	if len(key) > 40 {
+		t.Fatalf("dashboard UID length = %d, want <= 40", len(key))
+	}
+	if key != detailDashboardKey(topic) {
+		t.Fatal("detail dashboard key is not deterministic")
+	}
+	if key == detailDashboardKey("data/powertrain/oil-pressure") {
+		t.Fatal("different topics must not share a detail dashboard key")
+	}
+
+	wantURL := "/d/" + key + "?from=${__from}&to=${__to}"
+	if got := detailDashboardURL(topic); got != wantURL {
+		t.Errorf("detail dashboard URL = %q, want %q", got, wantURL)
 	}
 }

--- a/config/go.mod
+++ b/config/go.mod
@@ -2,6 +2,6 @@ module github.com/ApexCorse/ephoros/config
 
 go 1.25.1
 
-require github.com/ApexCorse/vera v0.0.0-20251030092832-2a4b5b476f0d
+require github.com/ApexCorse/vera v0.13.0
 
 require github.com/grafana/grafana-foundation-sdk/go v0.0.0-20251008104357-2e5c9f991a96

--- a/config/go.sum
+++ b/config/go.sum
@@ -1,5 +1,5 @@
-github.com/ApexCorse/vera v0.0.0-20251030092832-2a4b5b476f0d h1:DtLm7MoKpy6MKmuSngODcMUDK3y/kVLemuwWnpGD5OU=
-github.com/ApexCorse/vera v0.0.0-20251030092832-2a4b5b476f0d/go.mod h1:WGkLG8x6U4B3Fhnr4k3at0Ebam6qHBbUR9x57L6SBv8=
+github.com/ApexCorse/vera v0.13.0 h1:HbPcwrwgoAvNh0iH4s/St2wL1/pBYh/RjH8FGcp1Heg=
+github.com/ApexCorse/vera v0.13.0/go.mod h1:WGkLG8x6U4B3Fhnr4k3at0Ebam6qHBbUR9x57L6SBv8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/grafana/grafana-foundation-sdk/go v0.0.0-20251008104357-2e5c9f991a96 h1:dWUMXBaBDpiLYDWlxHQIFySY/+r3ekjupiqEPVWvTWE=


### PR DESCRIPTION
## Summary

- Add a stable vehicle telemetry overview dashboard with live and historical signal panels.
- Generate deterministic per-signal detail dashboards and dashboard links.
- Provision InfluxDB threshold and stale-data alerts with dashboard associations.
- Update MQTT topic mappings and add comprehensive dashboard and alerting tests.

## Testing

- Added unit tests for dashboard generation, topic validation, alert expressions, deterministic output, and JSON provisioning.
- Verified generated alert provisioning uses InfluxDB rather than MQTT.