### PR TITLE
test: expand simulator and config coverage

### DIFF
--- a/config/alerting_test.go
+++ b/config/alerting_test.go
@@ -5,247 +5,214 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"reflect"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestBuildAlertProvisioningCreatesInfluxThresholdBands(t *testing.T) {
-	warningLow := 600.0
-	warningHigh := 6_500.0
-	criticalLow := 300.0
-	criticalHigh := 7_000.0
-	staleSeconds := 30
+func float64Pointer(value float64) *float64 { return &value }
+func intPointer(value int) *int             { return &value }
 
-	provisioning, err := buildAlertProvisioning([]AlertSignal{{
-		Topic:             "data/powertrain/engine-speed",
-		WarningLow:        &warningLow,
-		WarningHigh:       &warningHigh,
-		CriticalLow:       &criticalLow,
-		CriticalHigh:      &criticalHigh,
-		StaleAfterSeconds: &staleSeconds,
-		DashboardUID:      "generated-telemetry",
-		PanelID:           12,
-	}})
-	if err != nil {
-		t.Fatalf("build alert provisioning: %v", err)
-	}
-
-	if provisioning.APIVersion != 1 {
-		t.Fatalf("apiVersion = %d, want 1", provisioning.APIVersion)
-	}
-	if len(provisioning.Groups) != 1 {
-		t.Fatalf("groups = %d, want 1", len(provisioning.Groups))
-	}
-	group := provisioning.Groups[0]
-	if group.Interval != "10s" {
-		t.Errorf("evaluation interval = %q, want 10s", group.Interval)
-	}
-	if len(group.Rules) != 3 {
-		t.Fatalf("rules = %d, want warning, critical, and stale", len(group.Rules))
-	}
-
-	warning := group.Rules[0]
-	if warning.Labels["severity"] != "warning" || warning.Labels["topic"] != "data/powertrain/engine-speed" {
-		t.Errorf("warning labels = %#v", warning.Labels)
-	}
-	if warning.DashboardUID != "generated-telemetry" || warning.PanelID != 12 {
-		t.Errorf("warning dashboard link = %q/%d", warning.DashboardUID, warning.PanelID)
-	}
-	if warning.NoDataState != "OK" {
-		t.Errorf("warning no-data state = %q, want OK when a stale rule exists", warning.NoDataState)
-	}
-	assertAlertData(t, warning, 30, "(($B <= 600 && $B > 300) || ($B >= 6500 && $B < 7000))")
-
-	critical := group.Rules[1]
-	if critical.Labels["severity"] != "critical" {
-		t.Errorf("critical severity = %q", critical.Labels["severity"])
-	}
-	assertAlertData(t, critical, 30, "($B <= 300 || $B >= 7000)")
-
-	stale := group.Rules[2]
-	if stale.Labels["severity"] != "warning" {
-		t.Errorf("stale severity = %q", stale.Labels["severity"])
-	}
-	if stale.NoDataState != "Alerting" {
-		t.Errorf("stale no-data state = %q, want Alerting", stale.NoDataState)
-	}
-	assertAlertData(t, stale, 30, "is_number($B) == 0")
-}
-
-func TestBuildAlertProvisioningUsesNoDataStateWithoutStalePolicy(t *testing.T) {
-	warningHigh := 80.0
-	provisioning, err := buildAlertProvisioning([]AlertSignal{{
-		Topic:       "data/electrical/battery-temperature",
-		WarningHigh: &warningHigh,
-	}})
-	if err != nil {
-		t.Fatalf("build alert provisioning: %v", err)
+func TestBuildAlertProvisioning(t *testing.T) {
+	tests := []struct {
+		name               string
+		signals            []AlertSignal
+		wantRuleCount      int
+		wantTopics         []string
+		wantSeverities     []string
+		wantNoDataStates   []string
+		wantLookbacks      []int
+		wantConditions     []string
+		wantDashboardUID   string
+		wantDashboardPanel int
+	}{
+		{
+			name: "warning critical and stale bands",
+			signals: []AlertSignal{{
+				Topic: "data/powertrain/engine-speed", WarningLow: float64Pointer(600),
+				WarningHigh: float64Pointer(6500), CriticalLow: float64Pointer(300),
+				CriticalHigh: float64Pointer(7000), StaleAfterSeconds: intPointer(30),
+				DashboardUID: "generated-telemetry", PanelID: 12,
+			}},
+			wantRuleCount: 3, wantTopics: []string{"data/powertrain/engine-speed", "data/powertrain/engine-speed", "data/powertrain/engine-speed"},
+			wantSeverities: []string{"warning", "critical", "warning"}, wantNoDataStates: []string{"OK", "OK", "Alerting"},
+			wantLookbacks: []int{30, 30, 30}, wantConditions: []string{"(($B <= 600 && $B > 300) || ($B >= 6500 && $B < 7000))", "($B <= 300 || $B >= 7000)", "is_number($B) == 0"},
+			wantDashboardUID: "generated-telemetry", wantDashboardPanel: 12,
+		},
+		{
+			name:          "threshold without stale policy uses default lookback",
+			signals:       []AlertSignal{{Topic: "data/electrical/battery-temperature", WarningHigh: float64Pointer(80)}},
+			wantRuleCount: 1, wantTopics: []string{"data/electrical/battery-temperature"}, wantSeverities: []string{"warning"},
+			wantNoDataStates: []string{"NoData"}, wantLookbacks: []int{alertDefaultLookbackSecs}, wantConditions: []string{"$B >= 80"},
+		},
+		{
+			name:          "signals without policies produce no rules",
+			signals:       []AlertSignal{{Topic: "data/interior/ambient-light"}},
+			wantRuleCount: 0,
+		},
 	}
 
-	rule := provisioning.Groups[0].Rules[0]
-	if rule.NoDataState != "NoData" {
-		t.Errorf("no-data state = %q, want NoData", rule.NoDataState)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provisioning, err := buildAlertProvisioning(test.signals)
+			require.NoError(t, err)
+			require.Equal(t, 1, provisioning.APIVersion)
+			require.Len(t, provisioning.Groups, 1)
+			group := provisioning.Groups[0]
+			assert.Equal(t, alertEvaluationInterval, group.Interval)
+			assert.Equal(t, alertFolder, group.Folder)
+			require.Len(t, group.Rules, test.wantRuleCount)
+
+			for index, rule := range group.Rules {
+				assert.Equal(t, test.wantTopics[index], rule.Labels["topic"])
+				assert.Equal(t, test.wantSeverities[index], rule.Labels["severity"])
+				assert.Equal(t, test.wantNoDataStates[index], rule.NoDataState)
+				assert.LessOrEqual(t, len(rule.UID), 40)
+				assertAlertData(t, rule, test.wantLookbacks[index], test.wantConditions[index])
+			}
+			if test.wantDashboardUID != "" {
+				assert.Equal(t, test.wantDashboardUID, group.Rules[0].DashboardUID)
+				assert.Equal(t, test.wantDashboardPanel, group.Rules[0].PanelID)
+			}
+		})
 	}
-	assertAlertData(t, rule, alertDefaultLookbackSecs, "$B >= 80")
 }
 
 func TestBuildAlertProvisioningIsDeterministic(t *testing.T) {
-	low := 1.0
-	high := 2.0
-	first := []AlertSignal{
-		{Topic: "data/zeta/value", CriticalHigh: &high},
-		{Topic: "data/alpha/value", WarningLow: &low},
-	}
-	second := []AlertSignal{first[1], first[0]}
-
-	left, err := buildAlertProvisioning(first)
-	if err != nil {
-		t.Fatalf("build first provisioning: %v", err)
-	}
-	right, err := buildAlertProvisioning(second)
-	if err != nil {
-		t.Fatalf("build second provisioning: %v", err)
-	}
-	if !reflect.DeepEqual(left, right) {
-		t.Fatalf("provisioning differs when input order changes\nleft: %#v\nright: %#v", left, right)
+	tests := []struct {
+		name   string
+		first  []AlertSignal
+		second []AlertSignal
+	}{
+		{
+			name:   "input order does not affect output",
+			first:  []AlertSignal{{Topic: "data/zeta/value", CriticalHigh: float64Pointer(2)}, {Topic: "data/alpha/value", WarningLow: float64Pointer(1)}},
+			second: []AlertSignal{{Topic: "data/alpha/value", WarningLow: float64Pointer(1)}, {Topic: "data/zeta/value", CriticalHigh: float64Pointer(2)}},
+		},
 	}
 
-	rules := left.Groups[0].Rules
-	if rules[0].Labels["topic"] != "data/alpha/value" || rules[1].Labels["topic"] != "data/zeta/value" {
-		t.Errorf("rules are not sorted by topic: %#v", rules)
-	}
-	for _, rule := range rules {
-		if len(rule.UID) > 40 {
-			t.Errorf("rule UID %q exceeds Grafana's 40-character limit", rule.UID)
-		}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			left, err := buildAlertProvisioning(test.first)
+			require.NoError(t, err)
+			right, err := buildAlertProvisioning(test.second)
+			require.NoError(t, err)
+			assert.Equal(t, left, right)
+			rules := left.Groups[0].Rules
+			require.Len(t, rules, 2)
+			assert.Equal(t, "data/alpha/value", rules[0].Labels["topic"])
+			assert.Equal(t, "data/zeta/value", rules[1].Labels["topic"])
+		})
 	}
 }
 
-func TestWriteAlertProvisioningWritesValidJSON(t *testing.T) {
-	criticalHigh := 100.0
-	path := filepath.Join(t.TempDir(), "nested", "alerts.json")
-	if err := WriteAlertProvisioning(path, []AlertSignal{{
-		Topic:        "data/electrical/voltage",
-		CriticalHigh: &criticalHigh,
-	}}); err != nil {
-		t.Fatalf("write alert provisioning: %v", err)
+func TestWriteAlertProvisioning(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        func(string) string
+		wantError   string
+		wantContent []string
+	}{
+		{name: "rejects empty path", path: func(string) string { return " \t" }, wantError: "path cannot be empty"},
+		{
+			name:        "writes valid influx JSON in nested directory",
+			path:        func(root string) string { return filepath.Join(root, "nested", "alerts.json") },
+			wantContent: []string{"\"datasourceUid\": \"influxdb-datasource\"", "\"apiVersion\": 1"},
+		},
 	}
 
-	contents, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read alert provisioning: %v", err)
-	}
-	var decoded map[string]any
-	if err := json.Unmarshal(contents, &decoded); err != nil {
-		t.Fatalf("generated provisioning is not JSON: %v", err)
-	}
-	if !strings.HasSuffix(string(contents), "\n") {
-		t.Error("generated provisioning should end with a newline")
-	}
-	if strings.Contains(string(contents), "mqtt-datasource") {
-		t.Error("generated alert provisioning must not query the MQTT datasource")
-	}
-	if !strings.Contains(string(contents), `"datasourceUid": "influxdb-datasource"`) {
-		t.Error("generated alert provisioning does not query InfluxDB")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := test.path(t.TempDir())
+			err := WriteAlertProvisioning(path, []AlertSignal{{Topic: "data/electrical/voltage", CriticalHigh: float64Pointer(100)}})
+			if test.wantError != "" {
+				require.ErrorContains(t, err, test.wantError)
+				return
+			}
+			require.NoError(t, err)
+			contents, err := os.ReadFile(path)
+			require.NoError(t, err)
+			var decoded map[string]any
+			require.NoError(t, json.Unmarshal(contents, &decoded))
+			assert.NotEmpty(t, decoded)
+			assert.Equal(t, byte('\n'), contents[len(contents)-1])
+			assert.NotContains(t, string(contents), "mqtt-datasource")
+			for _, expected := range test.wantContent {
+				assert.Contains(t, string(contents), expected)
+			}
+		})
 	}
 }
 
 func TestBuildAlertProvisioningRejectsInvalidSignals(t *testing.T) {
-	zero := 0
-	nan := math.NaN()
-	criticalLow := 300.0
-	warningLow := 200.0
-	high := 100.0
-
 	tests := []struct {
 		name    string
 		signals []AlertSignal
 		want    string
 	}{
 		{name: "empty topic", signals: []AlertSignal{{}}, want: "topic cannot be empty"},
-		{
-			name: "duplicate topic",
-			signals: []AlertSignal{
-				{Topic: "data/a/value", WarningHigh: &high},
-				{Topic: "data/a/value", CriticalHigh: &high},
-			},
-			want: "duplicate alert topic",
-		},
-		{
-			name:    "partial dashboard link",
-			signals: []AlertSignal{{Topic: "data/a/value", DashboardUID: "dashboard"}},
-			want:    "must be provided together",
-		},
-		{
-			name:    "non-positive stale interval",
-			signals: []AlertSignal{{Topic: "data/a/value", StaleAfterSeconds: &zero}},
-			want:    "must be positive",
-		},
-		{
-			name:    "non-finite threshold",
-			signals: []AlertSignal{{Topic: "data/a/value", CriticalHigh: &nan}},
-			want:    "must be finite",
-		},
-		{
-			name: "misordered thresholds",
-			signals: []AlertSignal{{
-				Topic:       "data/a/value",
-				CriticalLow: &criticalLow,
-				WarningLow:  &warningLow,
-			}},
-			want: "critical low threshold must be less than warning low threshold",
-		},
+		{name: "duplicate topic", signals: []AlertSignal{{Topic: "data/a/value", WarningHigh: float64Pointer(100)}, {Topic: "data/a/value", CriticalHigh: float64Pointer(100)}}, want: "duplicate alert topic"},
+		{name: "UID without panel", signals: []AlertSignal{{Topic: "data/a/value", DashboardUID: "dashboard"}}, want: "must be provided together"},
+		{name: "panel without UID", signals: []AlertSignal{{Topic: "data/a/value", PanelID: 1}}, want: "must be provided together"},
+		{name: "negative panel ID", signals: []AlertSignal{{Topic: "data/a/value", DashboardUID: "dashboard", PanelID: -1}}, want: "panel ID must be positive"},
+		{name: "zero stale interval", signals: []AlertSignal{{Topic: "data/a/value", StaleAfterSeconds: intPointer(0)}}, want: "must be positive"},
+		{name: "negative stale interval", signals: []AlertSignal{{Topic: "data/a/value", StaleAfterSeconds: intPointer(-1)}}, want: "must be positive"},
+		{name: "NaN threshold", signals: []AlertSignal{{Topic: "data/a/value", CriticalHigh: float64Pointer(math.NaN())}}, want: "must be finite"},
+		{name: "infinite threshold", signals: []AlertSignal{{Topic: "data/a/value", WarningLow: float64Pointer(math.Inf(1))}}, want: "must be finite"},
+		{name: "descending thresholds", signals: []AlertSignal{{Topic: "data/a/value", CriticalLow: float64Pointer(300), WarningLow: float64Pointer(200)}}, want: "critical low threshold must be less than warning low threshold"},
+		{name: "equal thresholds", signals: []AlertSignal{{Topic: "data/a/value", WarningHigh: float64Pointer(100), CriticalHigh: float64Pointer(100)}}, want: "warning high threshold must be less than critical high threshold"},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := buildAlertProvisioning(test.signals)
-			if err == nil || !strings.Contains(err.Error(), test.want) {
-				t.Fatalf("error = %v, want containing %q", err, test.want)
-			}
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func TestAlertExpressions(t *testing.T) {
+	tests := []struct {
+		name         string
+		signal       AlertSignal
+		wantWarning  string
+		wantCritical string
+	}{
+		{name: "none", signal: AlertSignal{}, wantWarning: "", wantCritical: ""},
+		{name: "warning low only", signal: AlertSignal{WarningLow: float64Pointer(1.25)}, wantWarning: "$B <= 1.25"},
+		{name: "critical high only", signal: AlertSignal{CriticalHigh: float64Pointer(2e6)}, wantCritical: "$B >= 2e+06"},
+		{name: "both warning bounds", signal: AlertSignal{WarningLow: float64Pointer(-1), WarningHigh: float64Pointer(1)}, wantWarning: "($B <= -1 || $B >= 1)"},
+		{name: "both critical bounds", signal: AlertSignal{CriticalLow: float64Pointer(-2), CriticalHigh: float64Pointer(2)}, wantCritical: "($B <= -2 || $B >= 2)"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.wantWarning, buildWarningExpression(test.signal))
+			assert.Equal(t, test.wantCritical, buildCriticalExpression(test.signal))
 		})
 	}
 }
 
 func assertAlertData(t *testing.T, rule alertRule, wantLookback int, wantCondition string) {
 	t.Helper()
-	if len(rule.Data) != 3 {
-		t.Fatalf("data stages = %d, want 3", len(rule.Data))
-	}
-
+	require.Len(t, rule.Data, 3)
 	query := rule.Data[0]
-	if query.DatasourceUID != alertDatasourceUID {
-		t.Errorf("query datasource = %q, want %q", query.DatasourceUID, alertDatasourceUID)
-	}
-	if query.RelativeTimeRange.From != wantLookback || query.RelativeTimeRange.To != 0 {
-		t.Errorf("query time range = %#v, want from=%d to=0", query.RelativeTimeRange, wantLookback)
-	}
+	assert.Equal(t, alertDatasourceUID, query.DatasourceUID)
+	assert.Equal(t, alertRelativeTimeRange{From: wantLookback}, query.RelativeTimeRange)
 	model, ok := query.Model.(influxAlertModel)
-	if !ok {
-		t.Fatalf("query model type = %T, want influxAlertModel", query.Model)
+	require.True(t, ok)
+	for _, expected := range []string{`from(bucket: "telemetry")`, `r["_measurement"] == "can_signal"`, `r["_field"] == "value"`, `r["topic"] == "data/`, `|> last()`} {
+		assert.Contains(t, model.Query, expected)
 	}
-	for _, expected := range []string{
-		`from(bucket: "telemetry")`,
-		`r["_measurement"] == "can_signal"`,
-		`r["_field"] == "value"`,
-		`r["topic"] == "data/`,
-		`|> last()`,
-	} {
-		if !strings.Contains(model.Query, expected) {
-			t.Errorf("Influx query does not contain %q:\n%s", expected, model.Query)
-		}
-	}
-
 	reduce, ok := rule.Data[1].Model.(expressionAlertModel)
-	if !ok || reduce.Type != "reduce" || reduce.Reducer != "last" || reduce.Expression != "A" {
-		t.Errorf("reduce model = %#v", rule.Data[1].Model)
-	}
+	require.True(t, ok)
+	assert.Equal(t, "reduce", reduce.Type)
+	assert.Equal(t, "last", reduce.Reducer)
+	assert.Equal(t, "A", reduce.Expression)
 	condition, ok := rule.Data[2].Model.(expressionAlertModel)
-	if !ok || condition.Type != "math" || condition.Expression != wantCondition {
-		t.Errorf("condition model = %#v, want expression %q", rule.Data[2].Model, wantCondition)
-	}
-	if rule.Condition != "C" {
-		t.Errorf("rule condition = %q, want C", rule.Condition)
-	}
+	require.True(t, ok)
+	assert.Equal(t, "math", condition.Type)
+	assert.Equal(t, wantCondition, condition.Expression)
+	assert.Equal(t, "C", rule.Condition)
 }

--- a/config/dashboards_test.go
+++ b/config/dashboards_test.go
@@ -6,176 +6,143 @@ import (
 	"testing"
 
 	"github.com/ApexCorse/vera"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestCreateDashboardsWithSignalTopicsBuildsStableOverviewAndDetails(t *testing.T) {
-	dashboards, err := createDashboardsWithSignalTopics([]vera.SignalTopic{
-		{Signal: "OilPressure", Topic: "data/powertrain/engine/oil-pressure"},
-		{Signal: "StateOfCharge", Topic: "data/electrical/battery/state-of-charge"},
-		{Signal: "EngineSpeed", Topic: "data/powertrain/engine-speed"},
-	})
-	if err != nil {
-		t.Fatalf("create dashboards: %v", err)
-	}
-	if len(dashboards) != 4 {
-		t.Fatalf("dashboard count = %d, want 4", len(dashboards))
-	}
-
-	telemetryDashboard, ok := dashboards["telemetry"]
-	if !ok {
-		t.Fatal("telemetry dashboard is missing")
-	}
-	encoded, err := json.Marshal(telemetryDashboard)
-	if err != nil {
-		t.Fatalf("marshal dashboard: %v", err)
-	}
-	generated := string(encoded)
-
-	for _, expected := range []string{
-		`"uid":"generated-telemetry"`,
-		`"refresh":"1s"`,
-		`"from":"now-15m"`,
-		`"type":"alertlist"`,
-		`"title":"Active Alerts"`,
-		`"viewMode":"list"`,
-		`"groupMode":"default"`,
-		`"sortOrder":3`,
-		`"dashboardAlerts":true`,
-		`"showInactiveAlerts":false`,
-		`"stateFilter":{"firing":true,"pending":true,"recovering":false,"noData":true,"normal":false,"error":true}`,
-		`"title":"Electrical"`,
-		`"title":"Powertrain"`,
-		`"title":"Battery / State Of Charge (live)"`,
-		`"title":"Engine / Oil Pressure (history)"`,
-		`"title":"Engine Speed (live)"`,
-		"grafana-mqtt-datasource",
-		"influxdb-datasource",
-		"data/powertrain/engine/oil-pressure",
-		`"graphMode":"area"`,
-		`"noValue":"No data"`,
-		`"collapsed":false`,
-		`"title":"Open detail"`,
-		`from=${__from}\u0026to=${__to}`,
-	} {
-		if !strings.Contains(generated, expected) {
-			t.Errorf("generated dashboard does not contain %q", expected)
-		}
-	}
-	if strings.Index(generated, `"title":"Active Alerts"`) > strings.Index(generated, `"title":"Electrical"`) {
-		t.Error("alert list is not the first dashboard panel")
+func TestCreateDashboardsWithSignalTopics(t *testing.T) {
+	tests := []struct {
+		name       string
+		topics     []vera.SignalTopic
+		wantCount  int
+		wantPieces []string
+	}{
+		{
+			name: "stable overview and detail dashboards",
+			topics: []vera.SignalTopic{
+				{Signal: "OilPressure", Topic: "data/powertrain/engine/oil-pressure"},
+				{Signal: "StateOfCharge", Topic: "data/electrical/battery/state-of-charge"},
+				{Signal: "EngineSpeed", Topic: "data/powertrain/engine-speed"},
+			},
+			wantCount: 4,
+			wantPieces: []string{
+				`"uid":"generated-telemetry"`, `"refresh":"1s"`, `"from":"now-15m"`, `"type":"alertlist"`,
+				`"title":"Active Alerts"`, `"viewMode":"list"`, `"dashboardAlerts":true`,
+				`"stateFilter":{"firing":true,"pending":true,"recovering":false,"noData":true,"normal":false,"error":true}`,
+				`"title":"Electrical"`, `"title":"Powertrain"`, `"title":"Battery / State Of Charge (live)"`,
+				`"title":"Engine / Oil Pressure (history)"`, `"title":"Engine Speed (live)"`,
+				"grafana-mqtt-datasource", "influxdb-datasource", `"graphMode":"area"`, `"noValue":"No data"`,
+				`"collapsed":false`, `"title":"Open detail"`, `from=${__from}\u0026to=${__to}`,
+			},
+		},
+		{name: "empty topic list still creates overview", topics: nil, wantCount: 1, wantPieces: []string{`"uid":"generated-telemetry"`, `"title":"Active Alerts"`}},
 	}
 
-	if strings.Index(generated, `"title":"Electrical"`) > strings.Index(generated, `"title":"Powertrain"`) {
-		t.Error("sections are not in alphabetical order")
-	}
-	if strings.Index(generated, `"title":"Engine / Oil Pressure (live)"`) > strings.Index(generated, `"title":"Engine Speed (live)"`) {
-		t.Error("signals are not in alphabetical order")
-	}
-
-	for _, topic := range []string{
-		"data/powertrain/engine/oil-pressure",
-		"data/electrical/battery/state-of-charge",
-		"data/powertrain/engine-speed",
-	} {
-		linkURL := strings.ReplaceAll(detailDashboardURL(topic), "&", `\u0026`)
-		if count := strings.Count(generated, linkURL); count != 2 {
-			t.Errorf("overview links to detail dashboard for %q %d times, want 2", topic, count)
-		}
-
-		key := detailDashboardKey(topic)
-		detailDashboard, ok := dashboards[key]
-		if !ok {
-			t.Errorf("detail dashboard for %q is missing", topic)
-			continue
-		}
-
-		detailJSON, err := json.Marshal(detailDashboard)
-		if err != nil {
-			t.Errorf("marshal detail dashboard for %q: %v", topic, err)
-			continue
-		}
-		generatedDetail := string(detailJSON)
-		for _, expected := range []string{
-			`"uid":"` + key + `"`,
-			`"refresh":"1s"`,
-			`"from":"now-24h"`,
-			topic,
-			"grafana-mqtt-datasource",
-			"influxdb-datasource",
-		} {
-			if !strings.Contains(generatedDetail, expected) {
-				t.Errorf("detail dashboard for %q does not contain %q", topic, expected)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dashboards, err := createDashboardsWithSignalTopics(test.topics)
+			require.NoError(t, err)
+			require.Len(t, dashboards, test.wantCount)
+			telemetryDashboard, ok := dashboards["telemetry"]
+			require.True(t, ok)
+			encoded, err := json.Marshal(telemetryDashboard)
+			require.NoError(t, err)
+			generated := string(encoded)
+			for _, expected := range test.wantPieces {
+				assert.Contains(t, generated, expected)
 			}
-		}
-	}
-}
-
-func TestParseSignalTopicHierarchyRejectsInvalidTopics(t *testing.T) {
-	for _, topic := range []string{
-		"vehicle/powertrain/engine-speed",
-		"data/powertrain",
-		"data//engine-speed",
-		"data/powertrain/",
-		"data/powertrain/engine-speed",
-	} {
-		t.Run(topic, func(t *testing.T) {
-			topics := []vera.SignalTopic{{Topic: topic}}
-			if topic == "data/powertrain/engine-speed" {
-				topics = append(topics, vera.SignalTopic{Topic: topic})
+			alertIndex := strings.Index(generated, `"title":"Active Alerts"`)
+			require.NotEqual(t, -1, alertIndex)
+			if electricalIndex := strings.Index(generated, `"title":"Electrical"`); electricalIndex >= 0 {
+				assert.Less(t, alertIndex, electricalIndex)
 			}
-			_, err := parseSignalTopicHierarchy(topics)
-			if err == nil {
-				t.Errorf("parseSignalTopicHierarchy(%q) succeeded, want error", topic)
+
+			for _, signalTopic := range test.topics {
+				topic := signalTopic.Topic
+				linkURL := strings.ReplaceAll(detailDashboardURL(topic), "&", `\u0026`)
+				assert.Equal(t, 2, strings.Count(generated, linkURL))
+				key := detailDashboardKey(topic)
+				detailDashboard, exists := dashboards[key]
+				require.True(t, exists)
+				detailJSON, err := json.Marshal(detailDashboard)
+				require.NoError(t, err)
+				generatedDetail := string(detailJSON)
+				for _, expected := range []string{`"uid":"` + key + `"`, `"refresh":"1s"`, `"from":"now-24h"`, topic, "grafana-mqtt-datasource", "influxdb-datasource"} {
+					assert.Contains(t, generatedDetail, expected)
+				}
 			}
 		})
 	}
 }
 
-func TestInfluxDBQueryUsesMQTTTopic(t *testing.T) {
-	query, err := NewInfluxDBQueryBuilder("data/electrical/battery-voltage").Build()
-	if err != nil {
-		t.Fatalf("build query: %v", err)
+func TestParseSignalTopicHierarchy(t *testing.T) {
+	tests := []struct {
+		name      string
+		topics    []vera.SignalTopic
+		want      []topicSection
+		wantError string
+	}{
+		{
+			name:   "groups and sorts sections and signals",
+			topics: []vera.SignalTopic{{Topic: "data/z_section/oil_temp"}, {Topic: "data/a-section/wheel-speed"}, {Topic: "data/a-section/brake/pressure"}},
+			want: []topicSection{
+				{name: "A Section", signals: []topicSignal{{label: "Brake / Pressure", topic: "data/a-section/brake/pressure"}, {label: "Wheel Speed", topic: "data/a-section/wheel-speed"}}},
+				{name: "Z Section", signals: []topicSignal{{label: "Oil Temp", topic: "data/z_section/oil_temp"}}},
+			},
+		},
+		{name: "rejects wrong prefix", topics: []vera.SignalTopic{{Topic: "vehicle/powertrain/engine-speed"}}, wantError: `must start with "data/"`},
+		{name: "rejects missing signal", topics: []vera.SignalTopic{{Topic: "data/powertrain"}}, wantError: "section and signal"},
+		{name: "rejects empty section", topics: []vera.SignalTopic{{Topic: "data//engine-speed"}}, wantError: "levels cannot be empty"},
+		{name: "rejects empty signal", topics: []vera.SignalTopic{{Topic: "data/powertrain/"}}, wantError: "levels cannot be empty"},
+		{name: "rejects duplicate", topics: []vera.SignalTopic{{Topic: "data/powertrain/engine-speed"}, {Topic: "data/powertrain/engine-speed"}}, wantError: "duplicate topic"},
 	}
 
-	influxQuery, ok := query.(InfluxDBQuery)
-	if !ok {
-		t.Fatalf("query type = %T, want InfluxDBQuery", query)
-	}
-	if !strings.Contains(influxQuery.Query, `r["topic"] == "data/electrical/battery-voltage"`) {
-		t.Errorf("query does not filter by the MQTT topic: %s", influxQuery.Query)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseSignalTopicHierarchy(test.topics)
+			if test.wantError != "" {
+				require.ErrorContains(t, err, test.wantError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
 	}
 }
 
-func TestStablePanelIDSeparatesPanelKinds(t *testing.T) {
-	topic := "data/powertrain/engine-speed"
-	live := stablePanelID(topic, 'l')
-	history := stablePanelID(topic, 'h')
-	if live == 0 || history == 0 {
-		t.Fatal("panel IDs must be non-zero")
+func TestHumanizeTopicSegment(t *testing.T) {
+	tests := []struct{ name, input, want string }{
+		{name: "hyphens", input: "state-of-charge", want: "State Of Charge"},
+		{name: "underscores", input: "oil_temp", want: "Oil Temp"},
+		{name: "unicode", input: "énergie-level", want: "Énergie Level"},
+		{name: "empty", input: "", want: ""},
 	}
-	if live == history {
-		t.Fatalf("live and history panel IDs collide: %d", live)
-	}
-	if stablePanelID(topic, 'l') != live {
-		t.Fatal("panel ID is not deterministic")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) { assert.Equal(t, test.want, humanizeTopicSegment(test.input)) })
 	}
 }
 
-func TestDetailDashboardKeyAndLinkAreStable(t *testing.T) {
-	topic := "data/powertrain/engine-speed"
-	key := detailDashboardKey(topic)
-	if len(key) > 40 {
-		t.Fatalf("dashboard UID length = %d, want <= 40", len(key))
+func TestStableIdentifiersAndLinks(t *testing.T) {
+	tests := []struct {
+		name  string
+		topic string
+	}{
+		{name: "powertrain signal", topic: "data/powertrain/engine-speed"},
+		{name: "unicode signal", topic: "data/interior/température"},
 	}
-	if key != detailDashboardKey(topic) {
-		t.Fatal("detail dashboard key is not deterministic")
-	}
-	if key == detailDashboardKey("data/powertrain/oil-pressure") {
-		t.Fatal("different topics must not share a detail dashboard key")
-	}
-
-	wantURL := "/d/" + key + "?from=${__from}&to=${__to}"
-	if got := detailDashboardURL(topic); got != wantURL {
-		t.Errorf("detail dashboard URL = %q, want %q", got, wantURL)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			live := stablePanelID(test.topic, 'l')
+			history := stablePanelID(test.topic, 'h')
+			assert.NotZero(t, live)
+			assert.NotZero(t, history)
+			assert.NotEqual(t, live, history)
+			assert.Equal(t, live, stablePanelID(test.topic, 'l'))
+			key := detailDashboardKey(test.topic)
+			assert.LessOrEqual(t, len(key), 40)
+			assert.Equal(t, key, detailDashboardKey(test.topic))
+			assert.NotEqual(t, key, detailDashboardKey(test.topic+"-different"))
+			assert.Equal(t, "/d/"+key+"?from=${__from}&to=${__to}", detailDashboardURL(test.topic))
+		})
 	}
 }

--- a/config/go.mod
+++ b/config/go.mod
@@ -5,3 +5,10 @@ go 1.25.1
 require github.com/ApexCorse/vera v0.13.0
 
 require github.com/grafana/grafana-foundation-sdk/go v0.0.0-20251008104357-2e5c9f991a96
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/config/go.sum
+++ b/config/go.sum
@@ -8,5 +8,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/config/main_test.go
+++ b/config/main_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validDBC = `VERSION "test"
+NS_ :
+BS_:
+BU_: ECU
+BO_ 256 Powertrain: 8 ECU
+ SG_ EngineSpeed : 0|16@1+ (1,0) [0|100] "rpm" ECU
+CM_ SG_ 256 EngineSpeed "vera:mqtt-topic=data/powertrain/engine-speed";
+`
+
+func TestGetDbcConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(*testing.T) string
+		wantError  string
+		wantTopics int
+	}{
+		{name: "missing environment variable", setup: func(t *testing.T) string { return "" }, wantError: "DBC_FILE_PATH env var is not set"},
+		{
+			name: "parses configured file",
+			setup: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "vehicle.dbc")
+				require.NoError(t, os.WriteFile(path, []byte(validDBC), 0o600))
+				return path
+			},
+			wantTopics: 1,
+		},
+		{
+			name: "falls back from config dbc to example",
+			setup: func(t *testing.T) string {
+				root := t.TempDir()
+				require.NoError(t, os.WriteFile(filepath.Join(root, "config.example.dbc"), []byte(validDBC), 0o600))
+				return filepath.Join(root, "config.dbc")
+			},
+			wantTopics: 1,
+		},
+		{name: "reports missing custom file", setup: func(t *testing.T) string { return filepath.Join(t.TempDir(), "missing.dbc") }, wantError: "error while opening DBC file"},
+		{
+			name: "reports malformed file",
+			setup: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "bad.dbc")
+				require.NoError(t, os.WriteFile(path, []byte("BO_ definitely-not-valid"), 0o600))
+				return path
+			},
+			wantError: "error in parsing DBC file",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("DBC_FILE_PATH", test.setup(t))
+			config, err := getDbcConfig()
+			if test.wantError != "" {
+				require.ErrorContains(t, err, test.wantError)
+				assert.Nil(t, config)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, config)
+			assert.Len(t, config.Topics, test.wantTopics)
+			assert.Equal(t, "data/powertrain/engine-speed", config.Topics[0].Topic)
+		})
+	}
+}
+
+func TestCleanProvisioningFolder(t *testing.T) {
+	tests := []struct {
+		name    string
+		prepare func(*testing.T, string)
+	}{
+		{name: "creates absent directory", prepare: func(*testing.T, string) {}},
+		{
+			name: "removes existing contents",
+			prepare: func(t *testing.T, path string) {
+				require.NoError(t, os.MkdirAll(filepath.Join(path, "nested"), 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(path, "nested", "stale.json"), []byte("stale"), 0o600))
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "dashboards")
+			test.prepare(t, path)
+			require.NoError(t, cleanProvisioningFolder(path))
+			entries, err := os.ReadDir(path)
+			require.NoError(t, err)
+			assert.Empty(t, entries)
+		})
+	}
+}
+
+func TestCreateProviderFile(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupPath func(*testing.T) string
+		wantError bool
+	}{
+		{
+			name: "writes provider configuration",
+			setupPath: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "dashboards")
+				require.NoError(t, os.MkdirAll(path, 0o755))
+				return path + string(os.PathSeparator)
+			},
+		},
+		{name: "reports missing directory", setupPath: func(t *testing.T) string { return filepath.Join(t.TempDir(), "missing") + string(os.PathSeparator) }, wantError: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := test.setupPath(t)
+			err := createProviderFile(path)
+			if test.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			contents, err := os.ReadFile(filepath.Join(path, "providers.yaml"))
+			require.NoError(t, err)
+			assert.Equal(t, providers, string(contents))
+		})
+	}
+}

--- a/config/query_test.go
+++ b/config/query_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/grafana/grafana-foundation-sdk/go/cog/variants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func boolPointer(value bool) *bool { return &value }
+
+func TestInfluxDBQueryBuilder(t *testing.T) {
+	tests := []struct {
+		name       string
+		bucket     string
+		topic      string
+		refID      string
+		hide       bool
+		wantBucket string
+	}{
+		{name: "defaults to telemetry bucket", topic: "data/electrical/battery-voltage", refID: "A", hide: true, wantBucket: "telemetry"},
+		{name: "uses configured bucket", bucket: "vehicle-metrics", topic: `data/interior/driver\"temperature`, refID: "B", hide: false, wantBucket: "vehicle-metrics"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("INFLUXDB_INIT_BUCKET", test.bucket)
+			query, err := NewInfluxDBQueryBuilder(test.topic).RefId(test.refID).Hide(test.hide).Build()
+			require.NoError(t, err)
+			got, ok := query.(InfluxDBQuery)
+			require.True(t, ok)
+			assert.Equal(t, test.refID, got.RefId)
+			assert.Equal(t, boolPointer(test.hide), got.Hide)
+			assert.True(t, got.RawQuery)
+			assert.Equal(t, "time_series", got.ResultFormat)
+			assert.Contains(t, got.Query, `from(bucket: "`+test.wantBucket+`")`)
+			assert.Contains(t, got.Query, `r["topic"] == `)
+			assert.Contains(t, got.Query, strconv.Quote(test.topic))
+			assert.Equal(t, "influxdb", got.DataqueryType())
+			require.NoError(t, got.Validate())
+		})
+	}
+}
+
+func TestInfluxDBQueryEquals(t *testing.T) {
+	base := InfluxDBQuery{RefId: "A", Query: "query", RawQuery: true, ResultFormat: "time_series"}
+	tests := []struct {
+		name  string
+		other variants.Dataquery
+		want  bool
+	}{
+		{name: "equal", other: base, want: true},
+		{name: "different ref ID", other: InfluxDBQuery{RefId: "B", Query: "query", RawQuery: true, ResultFormat: "time_series"}},
+		{name: "different query", other: InfluxDBQuery{RefId: "A", Query: "other", RawQuery: true, ResultFormat: "time_series"}},
+		{name: "different variant", other: MQTTQuery{Topic: "query"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) { assert.Equal(t, test.want, base.Equals(test.other)) })
+	}
+}
+
+func TestInfluxDBQueryVariantConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantError bool
+		want      *InfluxDBQuery
+	}{
+		{name: "unmarshals query", raw: `{"refId":"A","query":"from()","rawQuery":true,"resultFormat":"time_series"}`, want: &InfluxDBQuery{RefId: "A", Query: "from()", RawQuery: true, ResultFormat: "time_series"}},
+		{name: "rejects invalid JSON", raw: `{`, wantError: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := InfluxDBQueryVariantConfig()
+			assert.Equal(t, "influxdb", config.Identifier)
+			got, err := config.DataqueryUnmarshaler([]byte(test.raw))
+			if test.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestMQTTQueryBuilder(t *testing.T) {
+	tests := []struct {
+		name, topic, refID string
+		hide               bool
+	}{
+		{name: "visible query", topic: "data/powertrain/engine-speed", refID: "A", hide: false},
+		{name: "hidden query", topic: "data/electrical/voltage", refID: "B", hide: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			query, err := NewMQTTQueryBuilder(test.topic).RefId(test.refID).Hide(test.hide).Build()
+			require.NoError(t, err)
+			got, ok := query.(MQTTQuery)
+			require.True(t, ok)
+			assert.Equal(t, MQTTQuery{RefId: test.refID, Hide: boolPointer(test.hide), Topic: test.topic}, got)
+			assert.Equal(t, "custom", got.DataqueryType())
+			require.NoError(t, got.Validate())
+		})
+	}
+}
+
+func TestMQTTQueryEquals(t *testing.T) {
+	base := MQTTQuery{RefId: "A", Hide: boolPointer(false), Topic: "data/a/value"}
+	tests := []struct {
+		name  string
+		other variants.Dataquery
+		want  bool
+	}{
+		{name: "equal", other: MQTTQuery{RefId: "A", Hide: boolPointer(false), Topic: "data/a/value"}, want: true},
+		{name: "nil", other: nil},
+		{name: "different variant", other: InfluxDBQuery{}},
+		{name: "different ref ID", other: MQTTQuery{RefId: "B", Hide: boolPointer(false), Topic: "data/a/value"}},
+		{name: "nil hide differs", other: MQTTQuery{RefId: "A", Topic: "data/a/value"}},
+		{name: "hide differs", other: MQTTQuery{RefId: "A", Hide: boolPointer(true), Topic: "data/a/value"}},
+		{name: "topic differs", other: MQTTQuery{RefId: "A", Hide: boolPointer(false), Topic: "data/b/value"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) { assert.Equal(t, test.want, base.Equals(test.other)) })
+	}
+}
+
+func TestMQTTQueryVariantConfig(t *testing.T) {
+	tests := []struct {
+		name, raw string
+		wantError bool
+		want      *MQTTQuery
+	}{
+		{name: "unmarshals query", raw: `{"refId":"A","hide":true,"topic":"data/a/value"}`, want: &MQTTQuery{RefId: "A", Hide: boolPointer(true), Topic: "data/a/value"}},
+		{name: "rejects invalid JSON", raw: `{`, wantError: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := MQTTQueryVariantConfig()
+			assert.Equal(t, "mqtt-datasource", config.Identifier)
+			got, err := config.DataqueryUnmarshaler([]byte(test.raw))
+			if test.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/simulator/actions_test.go
+++ b/simulator/actions_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMQTTClientPublishValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		topic   string
+		payload []byte
+		wantErr string
+	}{
+		{name: "empty topic", payload: []byte("payload"), wantErr: "topic cannot be empty"},
+		{name: "nil payload", topic: "telemetry/speed", wantErr: "payload cannot be empty"},
+		{name: "empty payload", topic: "telemetry/speed", payload: []byte{}, wantErr: "payload cannot be empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewMQTTClient(nil)
+
+			err := client.Publish(context.Background(), tt.topic, tt.payload)
+
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
+}

--- a/simulator/client_test.go
+++ b/simulator/client_test.go
@@ -1,87 +1,200 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"net/url"
 	"testing"
 
 	"github.com/eclipse/paho.golang/autopaho"
 	"github.com/eclipse/paho.golang/paho"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewMQTTClient(t *testing.T) {
-	a := assert.New(t)
-	cm := &autopaho.ConnectionManager{}
-	c := NewMQTTClient(cm)
-	a.NotNil(c, "client should not be nil")
-	a.Equal(cm, c.c, "underlying connection manager should be set")
+	tests := []struct {
+		name string
+		cm   *autopaho.ConnectionManager
+	}{
+		{name: "connection manager", cm: &autopaho.ConnectionManager{}},
+		{name: "nil connection manager"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewMQTTClient(tt.cm)
+
+			require.NotNil(t, client)
+			assert.Same(t, tt.cm, client.c)
+		})
+	}
 }
 
-func TestNewMQTTClientBuilder_DefaultsAndAdders(t *testing.T) {
-	a := assert.New(t)
-
-	cfg := &autopaho.ClientConfig{
-		ClientConfig: paho.ClientConfig{},
+func TestNewMQTTClientBuilder(t *testing.T) {
+	existing := &autopaho.ClientConfig{KeepAlive: 12}
+	tests := []struct {
+		name string
+		cfg  *autopaho.ClientConfig
+		want *autopaho.ClientConfig
+	}{
+		{name: "uses provided config", cfg: existing, want: existing},
+		{name: "creates default config", want: &autopaho.ClientConfig{}},
 	}
-	b := NewMQTTClientBuilder(cfg)
-	a.NotNil(b)
-	a.NotNil(b.cfg)
 
-	// servers
-	urls := []*url.URL{{Scheme: "tcp", Host: "localhost:1883"}}
-	b.AddServers(urls)
-	a.Len(cfg.ServerUrls, 1)
-	a.Equal("localhost:1883", cfg.ServerUrls[0].Host)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewMQTTClientBuilder(tt.cfg)
 
-	b.AddKeepAlive(30)
-	a.Equal(uint16(30), cfg.KeepAlive)
+			require.NotNil(t, builder)
+			require.NotNil(t, builder.cfg)
+			if tt.cfg != nil {
+				assert.Same(t, tt.want, builder.cfg)
+			} else {
+				assert.Equal(t, tt.want, builder.cfg)
+			}
+		})
+	}
+}
 
-	b.AddCleanStartOnInitialConnection(true)
-	a.Equal(true, cfg.CleanStartOnInitialConnection)
+func TestMQTTClientBuilderAdders(t *testing.T) {
+	serverURL := &url.URL{Scheme: "tcp", Host: "localhost:1883"}
+	callbackErr := errors.New("callback error")
+	tests := []struct {
+		name   string
+		apply  func(*MQTTClientBuilder) *MQTTClientBuilder
+		assert func(*testing.T, *autopaho.ClientConfig)
+	}{
+		{
+			name:  "servers",
+			apply: func(b *MQTTClientBuilder) *MQTTClientBuilder { return b.AddServers([]*url.URL{serverURL}) },
+			assert: func(t *testing.T, cfg *autopaho.ClientConfig) {
+				require.Len(t, cfg.ServerUrls, 1)
+				assert.Same(t, serverURL, cfg.ServerUrls[0])
+			},
+		},
+		{
+			name:  "keep alive",
+			apply: func(b *MQTTClientBuilder) *MQTTClientBuilder { return b.AddKeepAlive(30) },
+			assert: func(t *testing.T, cfg *autopaho.ClientConfig) {
+				assert.Equal(t, uint16(30), cfg.KeepAlive)
+			},
+		},
+		{
+			name:  "clean start",
+			apply: func(b *MQTTClientBuilder) *MQTTClientBuilder { return b.AddCleanStartOnInitialConnection(true) },
+			assert: func(t *testing.T, cfg *autopaho.ClientConfig) {
+				assert.True(t, cfg.CleanStartOnInitialConnection)
+			},
+		},
+		{
+			name:  "session expiry",
+			apply: func(b *MQTTClientBuilder) *MQTTClientBuilder { return b.AddSessionExpiryInterval(12345) },
+			assert: func(t *testing.T, cfg *autopaho.ClientConfig) {
+				assert.Equal(t, uint32(12345), cfg.SessionExpiryInterval)
+			},
+		},
+		{
+			name: "connection up callback",
+			apply: func(b *MQTTClientBuilder) *MQTTClientBuilder {
+				return b.AddOnConnectionUp(func(*autopaho.ConnectionManager, *paho.Connack) {})
+			},
+			assert: func(t *testing.T, cfg *autopaho.ClientConfig) {
+				require.NotNil(t, cfg.OnConnectionUp)
+				assert.NotPanics(t, func() { cfg.OnConnectionUp(nil, nil) })
+			},
+		},
+		{
+			name: "connection error callback",
+			apply: func(b *MQTTClientBuilder) *MQTTClientBuilder {
+				return b.AddOnConnectionError(func(error) {})
+			},
+			assert: func(t *testing.T, cfg *autopaho.ClientConfig) {
+				require.NotNil(t, cfg.OnConnectError)
+				assert.NotPanics(t, func() { cfg.OnConnectError(callbackErr) })
+			},
+		},
+		{
+			name:  "client id",
+			apply: func(b *MQTTClientBuilder) *MQTTClientBuilder { return b.AddClientId("my-client") },
+			assert: func(t *testing.T, cfg *autopaho.ClientConfig) {
+				assert.Equal(t, "my-client", cfg.ClientConfig.ClientID)
+			},
+		},
+		{
+			name: "publish received callback",
+			apply: func(b *MQTTClientBuilder) *MQTTClientBuilder {
+				return b.AddOnPublishReceived(func(paho.PublishReceived) (bool, error) { return true, callbackErr })
+			},
+			assert: func(t *testing.T, cfg *autopaho.ClientConfig) {
+				require.Len(t, cfg.ClientConfig.OnPublishReceived, 1)
+				got, err := cfg.ClientConfig.OnPublishReceived[0](paho.PublishReceived{})
+				assert.True(t, got)
+				assert.ErrorIs(t, err, callbackErr)
+			},
+		},
+		{
+			name: "client error callback",
+			apply: func(b *MQTTClientBuilder) *MQTTClientBuilder {
+				return b.AddOnClientError(func(error) {})
+			},
+			assert: func(t *testing.T, cfg *autopaho.ClientConfig) {
+				require.NotNil(t, cfg.ClientConfig.OnClientError)
+				assert.NotPanics(t, func() { cfg.ClientConfig.OnClientError(callbackErr) })
+			},
+		},
+		{
+			name: "server disconnect callback",
+			apply: func(b *MQTTClientBuilder) *MQTTClientBuilder {
+				return b.AddOnServerDisconnect(func(*paho.Disconnect) {})
+			},
+			assert: func(t *testing.T, cfg *autopaho.ClientConfig) {
+				require.NotNil(t, cfg.ClientConfig.OnServerDisconnect)
+				assert.NotPanics(t, func() { cfg.ClientConfig.OnServerDisconnect(nil) })
+			},
+		},
+	}
 
-	b.AddSessionExpiryInterval(12345)
-	a.Equal(uint32(12345), cfg.SessionExpiryInterval)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &autopaho.ClientConfig{}
+			builder := NewMQTTClientBuilder(cfg)
 
-	flagOnConnUp := false
-	b.AddOnConnectionUp(func(cm *autopaho.ConnectionManager, connAck *paho.Connack) {
-		flagOnConnUp = true
-	})
-	a.NotNil(cfg.OnConnectionUp)
-	cfg.OnConnectionUp(nil, nil)
-	a.True(flagOnConnUp)
+			returned := tt.apply(builder)
 
-	flagOnConnErr := false
-	b.AddOnConnectionError(func(err error) {
-		flagOnConnErr = true
-	})
-	a.NotNil(cfg.OnConnectError)
-	cfg.OnConnectError(nil)
-	a.True(flagOnConnErr)
+			assert.Same(t, builder, returned)
+			tt.assert(t, cfg)
+		})
+	}
+}
 
-	b.AddClientId("my-client")
-	a.Equal("my-client", cfg.ClientConfig.ClientID)
+func TestMQTTClientBuilderBuildErrors(t *testing.T) {
+	canceledContext, cancel := context.WithCancel(context.Background())
+	cancel()
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		servers []*url.URL
+		wantErr string
+	}{
+		{name: "missing servers", ctx: context.Background(), wantErr: "no server urls provided"},
+		{
+			name:    "connection context canceled",
+			ctx:     canceledContext,
+			servers: []*url.URL{{Scheme: "tcp", Host: "127.0.0.1:1"}},
+			wantErr: context.Canceled.Error(),
+		},
+	}
 
-	b.AddOnPublishReceived(func(pr paho.PublishReceived) (bool, error) {
-		return true, nil
-	})
-	a.Len(cfg.ClientConfig.OnPublishReceived, 1)
-	ok, err := cfg.ClientConfig.OnPublishReceived[0](paho.PublishReceived{})
-	a.NoError(err)
-	a.True(ok)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewMQTTClientBuilder(nil).AddServers(tt.servers)
 
-	flagOnClientErr := false
-	b.AddOnClientError(func(err error) {
-		flagOnClientErr = true
-	})
-	a.NotNil(cfg.ClientConfig.OnClientError)
-	cfg.ClientConfig.OnClientError(nil)
-	a.True(flagOnClientErr)
+			client, err := builder.Build(tt.ctx)
 
-	flagOnServerDisc := false
-	b.AddOnServerDisconnect(func(d *paho.Disconnect) {
-		flagOnServerDisc = true
-	})
-	a.NotNil(cfg.ClientConfig.OnServerDisconnect)
-	cfg.ClientConfig.OnServerDisconnect(nil)
-	a.True(flagOnServerDisc)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.Nil(t, client)
+		})
+	}
 }

--- a/simulator/influx_test.go
+++ b/simulator/influx_test.go
@@ -2,55 +2,260 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestInfluxWriterWriteUsesDashboardSchema(t *testing.T) {
-	var gotRequest *http.Request
-	var gotBody string
-	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		gotRequest = request
-		body, err := io.ReadAll(request.Body)
-		if err != nil {
-			t.Fatal(err)
-		}
-		gotBody = string(body)
-		writer.WriteHeader(http.StatusNoContent)
-	}))
-	defer server.Close()
+type roundTripFunc func(*http.Request) (*http.Response, error)
 
-	baseURL, err := url.Parse(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	writer := &InfluxWriter{baseURL: baseURL, token: "test-token", org: "test-org", bucket: "test-bucket", client: server.Client()}
-	payload := []byte(`{"value":12.5,"time":"2026-08-10T12:30:00.123456789Z","unit":"V"}`)
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
 
-	if err := writer.Write(context.Background(), "data/electrical/battery voltage", payload); err != nil {
-		t.Fatal(err)
+func TestNewInfluxWriterFromEnvironment(t *testing.T) {
+	tests := []struct {
+		name        string
+		environment map[string]string
+		wantURL     string
+		wantOrg     string
+		wantBucket  string
+		wantErr     string
+	}{
+		{
+			name:        "defaults",
+			environment: map[string]string{"INFLUXDB_TOKEN": "token"},
+			wantURL:     defaultInfluxDBURL,
+			wantOrg:     defaultInfluxDBOrg,
+			wantBucket:  defaultInfluxDBBucket,
+		},
+		{
+			name: "custom values",
+			environment: map[string]string{
+				"INFLUXDB_URL":         "https://influx.example.test/base",
+				"INFLUXDB_TOKEN":       "custom-token",
+				"INFLUXDB_INIT_ORG":    "custom-org",
+				"INFLUXDB_INIT_BUCKET": "custom-bucket",
+			},
+			wantURL:    "https://influx.example.test/base",
+			wantOrg:    "custom-org",
+			wantBucket: "custom-bucket",
+		},
+		{
+			name:        "malformed URL",
+			environment: map[string]string{"INFLUXDB_URL": "://bad", "INFLUXDB_TOKEN": "token"},
+			wantErr:     "parse INFLUXDB_URL",
+		},
+		{
+			name:        "relative URL",
+			environment: map[string]string{"INFLUXDB_URL": "influxdb:8086", "INFLUXDB_TOKEN": "token"},
+			wantErr:     "INFLUXDB_URL must be an absolute URL",
+		},
+		{
+			name:        "missing token",
+			environment: map[string]string{"INFLUXDB_URL": "https://influx.example.test"},
+			wantErr:     "INFLUXDB_TOKEN env var is not set",
+		},
 	}
 
-	if gotRequest.URL.Path != "/api/v2/write" {
-		t.Errorf("path = %q, want /api/v2/write", gotRequest.URL.Path)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, name := range []string{"INFLUXDB_URL", "INFLUXDB_TOKEN", "INFLUXDB_INIT_ORG", "INFLUXDB_INIT_BUCKET"} {
+				t.Setenv(name, tt.environment[name])
+			}
+
+			writer, err := NewInfluxWriterFromEnvironment()
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, writer)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, writer)
+			assert.Equal(t, tt.wantURL, writer.baseURL.String())
+			assert.Equal(t, tt.environment["INFLUXDB_TOKEN"], writer.token)
+			assert.Equal(t, tt.wantOrg, writer.org)
+			assert.Equal(t, tt.wantBucket, writer.bucket)
+			assert.Same(t, http.DefaultClient, writer.client)
+		})
 	}
-	if gotRequest.URL.Query().Get("org") != "test-org" || gotRequest.URL.Query().Get("bucket") != "test-bucket" {
-		t.Errorf("query = %q, want org and bucket", gotRequest.URL.RawQuery)
+}
+
+func TestInfluxWriterWrite(t *testing.T) {
+	transportErr := errors.New("transport unavailable")
+	tests := []struct {
+		name      string
+		topic     string
+		payload   string
+		roundTrip roundTripFunc
+		wantErr   string
+		wantErrIs error
+	}{
+		{
+			name:    "dashboard schema request",
+			topic:   `data/electrical/battery voltage,primary=main\bus`,
+			payload: `{"value":12.5,"time":"2026-08-10T12:30:00.123456789Z","unit":"V"}`,
+			roundTrip: func(request *http.Request) (*http.Response, error) {
+				body, err := io.ReadAll(request.Body)
+				require.NoError(t, err)
+				assert.Equal(t, http.MethodPost, request.Method)
+				assert.Equal(t, "/api/v2/write", request.URL.Path)
+				assert.Equal(t, "test-org", request.URL.Query().Get("org"))
+				assert.Equal(t, "test-bucket", request.URL.Query().Get("bucket"))
+				assert.Equal(t, "ns", request.URL.Query().Get("precision"))
+				assert.Equal(t, "Token test-token", request.Header.Get("Authorization"))
+				assert.Equal(t, "text/plain; charset=utf-8", request.Header.Get("Content-Type"))
+				assert.Equal(t, "can_signal,topic=data/electrical/battery\\ voltage\\,primary\\=main\\\\bus value=12.5 1786365000123456789\n", string(body))
+				return response(http.StatusNoContent, ""), nil
+			},
+		},
+		{
+			name:    "invalid JSON",
+			topic:   "data/speed",
+			payload: `{`,
+			wantErr: "decode simulated payload",
+		},
+		{
+			name:    "invalid timestamp",
+			topic:   "data/speed",
+			payload: `{"value":1,"time":"not-a-time"}`,
+			wantErr: "parse simulated timestamp",
+		},
+		{
+			name:      "transport error",
+			topic:     "data/speed",
+			payload:   `{"value":1,"time":"2026-08-10T12:30:00Z"}`,
+			roundTrip: func(*http.Request) (*http.Response, error) { return nil, transportErr },
+			wantErr:   "write to InfluxDB",
+			wantErrIs: transportErr,
+		},
+		{
+			name:    "server error with body",
+			topic:   "data/speed",
+			payload: `{"value":1,"time":"2026-08-10T12:30:00Z"}`,
+			roundTrip: func(*http.Request) (*http.Response, error) {
+				return response(http.StatusBadRequest, "invalid line protocol\n"), nil
+			},
+			wantErr: "InfluxDB returned 400 Bad Request: invalid line protocol",
+		},
+		{
+			name:    "redirect status is rejected",
+			topic:   "data/speed",
+			payload: `{"value":1,"time":"2026-08-10T12:30:00Z"}`,
+			roundTrip: func(*http.Request) (*http.Response, error) {
+				return response(http.StatusPermanentRedirect, ""), nil
+			},
+			wantErr: "InfluxDB returned 308 Permanent Redirect",
+		},
 	}
-	if gotRequest.Header.Get("Authorization") != "Token test-token" {
-		t.Errorf("authorization = %q", gotRequest.Header.Get("Authorization"))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseURL, err := url.Parse("https://influx.example.test/base")
+			require.NoError(t, err)
+			client := &http.Client{}
+			if tt.roundTrip != nil {
+				client.Transport = tt.roundTrip
+			}
+			writer := &InfluxWriter{baseURL: baseURL, token: "test-token", org: "test-org", bucket: "test-bucket", client: client}
+
+			err = writer.Write(context.Background(), tt.topic, []byte(tt.payload))
+
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			if tt.wantErrIs != nil {
+				assert.ErrorIs(t, err, tt.wantErrIs)
+			}
+		})
 	}
-	if !strings.HasPrefix(gotBody, "can_signal,topic=data/electrical/battery\\ voltage value=12.5 1786365000123456789\n") {
-		t.Errorf("line protocol = %q", gotBody)
+}
+
+func TestEnvironmentOrDefault(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		fallback string
+		want     string
+	}{
+		{name: "environment value", value: "configured", fallback: "fallback", want: "configured"},
+		{name: "fallback", fallback: "fallback", want: "fallback"},
+		{name: "both empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("SIMULATOR_TEST_VALUE", tt.value)
+			assert.Equal(t, tt.want, environmentOrDefault("SIMULATOR_TEST_VALUE", tt.fallback))
+		})
+	}
+}
+
+func TestParseTimestamp(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    time.Time
+		wantErr string
+	}{
+		{name: "nanoseconds", value: "2026-08-10T12:30:00.123456789Z", want: time.Date(2026, 8, 10, 12, 30, 0, 123456789, time.UTC)},
+		{name: "timezone offset", value: "2026-08-10T14:30:00+02:00", want: time.Date(2026, 8, 10, 14, 30, 0, 0, time.FixedZone("", 2*60*60))},
+		{name: "empty", wantErr: "parse simulated timestamp"},
+		{name: "invalid", value: "10 August 2026", wantErr: "parse simulated timestamp"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTimestamp(tt.value)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.True(t, got.IsZero())
+				return
+			}
+			require.NoError(t, err)
+			assert.True(t, tt.want.Equal(got))
+		})
 	}
 }
 
 func TestEscapeInfluxTag(t *testing.T) {
-	if got, want := escapeInfluxTag(`a,b=c d\\e`), `a\,b\=c\ d\\\\e`; got != want {
-		t.Errorf("escapeInfluxTag() = %q, want %q", got, want)
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "plain", value: "vehicle/speed", want: "vehicle/speed"},
+		{name: "reserved characters", value: `a,b=c d\e`, want: `a\,b\=c\ d\\e`},
+		{name: "empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, escapeInfluxTag(tt.value))
+		})
+	}
+}
+
+func response(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
 	}
 }

--- a/simulator/main_test.go
+++ b/simulator/main_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ApexCorse/vera"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validDBC = `BO_ 123 Vehicle: 8 ECU
+	SG_ Speed : 0|16@1+ (0.1,0) [0|100] "km/h" Gateway
+CM_ SG_ 123 Speed "vera:mqtt-topic=vehicle/speed";`
+
+func TestGenerateRandomData(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "first payload"},
+		{name: "second payload"},
+		{name: "third payload"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := time.Now()
+			data, err := generateRandomData()
+			after := time.Now()
+
+			require.NoError(t, err)
+			var payload struct {
+				Value float32   `json:"value"`
+				Time  time.Time `json:"time"`
+				Unit  string    `json:"unit"`
+			}
+			require.NoError(t, json.Unmarshal(data, &payload))
+			assert.GreaterOrEqual(t, payload.Value, float32(-500))
+			assert.Less(t, payload.Value, float32(500))
+			assert.Equal(t, "V", payload.Unit)
+			assert.False(t, payload.Time.Before(before))
+			assert.False(t, payload.Time.After(after))
+		})
+	}
+}
+
+func TestGetDbcConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		requested  string
+		files      map[string]string
+		wantTopics []string
+		wantErr    string
+	}{
+		{
+			name:       "requested file",
+			requested:  "vehicle.dbc",
+			files:      map[string]string{"vehicle.dbc": validDBC},
+			wantTopics: []string{"vehicle/speed"},
+		},
+		{
+			name:       "example fallback for missing config dbc",
+			requested:  "config.dbc",
+			files:      map[string]string{"config.example.dbc": validDBC},
+			wantTopics: []string{"vehicle/speed"},
+		},
+		{
+			name:      "missing non-default file",
+			requested: "vehicle.dbc",
+			wantErr:   "error while opening DBC file",
+		},
+		{
+			name:      "missing fallback file",
+			requested: "config.dbc",
+			wantErr:   "error while opening DBC file",
+		},
+		{
+			name:      "parse error",
+			requested: "invalid.dbc",
+			files: map[string]string{
+				"invalid.dbc": `CM_ SG_ 123 Speed "vera:mqtt-topic=vehicle/speed"`,
+			},
+			wantErr: "error in parsing DBC file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			directory := t.TempDir()
+			for name, contents := range tt.files {
+				require.NoError(t, os.WriteFile(filepath.Join(directory, name), []byte(contents), 0o600))
+			}
+
+			config, err := getDbcConfig(filepath.Join(directory, tt.requested))
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, config)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, config)
+			assert.Equal(t, tt.wantTopics, getTopicsFromConfig(config))
+		})
+	}
+}
+
+func TestWriteTopicCatalog(t *testing.T) {
+	tests := []struct {
+		name    string
+		topics  []string
+		path    func(string) string
+		want    string
+		wantErr string
+	}{
+		{
+			name:   "writes header",
+			topics: []string{"vehicle/speed", `vehicle/quoted"topic`, `vehicle/back\\slash`},
+			path:   func(directory string) string { return filepath.Join(directory, "topics.h") },
+			want: "// Code generated from config.dbc; DO NOT EDIT.\n#pragma once\n\n" +
+				"#define EPHOROS_TELEMETRY_SIMULATOR_TOPIC_COUNT 3\n\n" +
+				"static const char * const ephoros_telemetry_simulator_topics[] = {\n" +
+				"\t\"vehicle/speed\",\n\t\"vehicle/quoted\\\"topic\",\n\t\"vehicle/back\\\\\\\\slash\",\n};\n",
+		},
+		{
+			name:    "rejects empty topics",
+			path:    func(directory string) string { return filepath.Join(directory, "topics.h") },
+			wantErr: "DBC config contains no MQTT topics",
+		},
+		{
+			name:    "create error",
+			topics:  []string{"vehicle/speed"},
+			path:    func(directory string) string { return directory },
+			wantErr: "is a directory",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			directory := t.TempDir()
+			outputPath := tt.path(directory)
+
+			err := writeTopicCatalog(outputPath, tt.topics)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			contents, err := os.ReadFile(outputPath)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(contents))
+		})
+	}
+}
+
+func TestGetTopicsFromConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *vera.Config
+		want   []string
+	}{
+		{name: "empty", config: &vera.Config{}, want: []string{}},
+		{
+			name: "preserves topic order and duplicates",
+			config: &vera.Config{Topics: []vera.SignalTopic{
+				{MessageID: 1, Signal: "Speed", Topic: "vehicle/speed"},
+				{MessageID: 2, Signal: "Voltage", Topic: "vehicle/voltage"},
+				{MessageID: 3, Signal: "SpeedBackup", Topic: "vehicle/speed"},
+			}},
+			want: []string{"vehicle/speed", "vehicle/voltage", "vehicle/speed"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, getTopicsFromConfig(tt.config))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Expand configuration tests for DBC loading, provisioning, dashboards, alerts, and queries.
- Add simulator coverage for actions, clients, InfluxDB integration, and startup behavior.
- Add a representative CAN DBC fixture and Testify dependencies.

## Testing

- `go test ./...` in `config/`
- `go test ./...` in `simulator/`