### PR TITLE
feat: provision Grafana alerts from DBC signal metadata

### DIFF
--- a/config.example.dbc
+++ b/config.example.dbc
@@ -6,6 +6,8 @@ BS_:
 
 BU_: ECU DASH
 
+BA_DEF_ SG_ "VeraMqttTopic" STRING ;
+
 BO_ 256 Powertrain: 8 ECU
     SG_ EngineSpeed : 0|16@1+ (0.25,0) [0|16000] "rpm" DASH
     SG_ ThrottlePosition : 16|8@1+ (0.4,0) [0|100] "%" DASH
@@ -22,13 +24,13 @@ BO_ 258 VehicleDynamics: 8 ECU
     SG_ SteeringAngle : 16|16@1- (0.1,0) [-3276.8|3276.7] "deg" DASH
     SG_ BrakePressure : 32|12@1+ (0.1,0) [0|400] "bar" DASH
 
-CM_ SG_ 256 EngineSpeed "vera:mqtt-topic=vehicle/engine/speed";
-CM_ SG_ 256 ThrottlePosition "vera:mqtt-topic=vehicle/engine/throttle";
-CM_ SG_ 256 CoolantTemperature "vera:mqtt-topic=vehicle/engine/coolant";
-CM_ SG_ 256 OilPressure "vera:mqtt-topic=vehicle/engine/oil-pressure";
-CM_ SG_ 257 BatteryVoltage "vera:mqtt-topic=vehicle/battery/voltage";
-CM_ SG_ 257 BatteryCurrent "vera:mqtt-topic=vehicle/battery/current";
-CM_ SG_ 257 BatteryTemperature "vera:mqtt-topic=vehicle/battery/temperature";
-CM_ SG_ 258 VehicleSpeed "vera:mqtt-topic=vehicle/dynamics/speed";
-CM_ SG_ 258 SteeringAngle "vera:mqtt-topic=vehicle/dynamics/steering";
-CM_ SG_ 258 BrakePressure "vera:mqtt-topic=vehicle/dynamics/brake";
+BA_ "VeraMqttTopic" SG_ 256 EngineSpeed "data/powertrain/engine/speed";
+BA_ "VeraMqttTopic" SG_ 256 ThrottlePosition "data/powertrain/engine/throttle";
+BA_ "VeraMqttTopic" SG_ 256 CoolantTemperature "data/powertrain/engine/coolant";
+BA_ "VeraMqttTopic" SG_ 256 OilPressure "data/powertrain/engine/oil-pressure";
+BA_ "VeraMqttTopic" SG_ 257 BatteryVoltage "data/battery/voltage";
+BA_ "VeraMqttTopic" SG_ 257 BatteryCurrent "data/battery/current";
+BA_ "VeraMqttTopic" SG_ 257 BatteryTemperature "data/battery/temperature";
+BA_ "VeraMqttTopic" SG_ 258 VehicleSpeed "data/dynamics/speed";
+BA_ "VeraMqttTopic" SG_ 258 SteeringAngle "data/dynamics/steering";
+BA_ "VeraMqttTopic" SG_ 258 BrakePressure "data/dynamics/brake";

--- a/config/alerting.go
+++ b/config/alerting.go
@@ -229,9 +229,9 @@ func validateAlertSignal(signal AlertSignal) error {
 		if math.IsNaN(*threshold.value) || math.IsInf(*threshold.value, 0) {
 			return fmt.Errorf("%s threshold must be finite for topic %q", threshold.name, signal.Topic)
 		}
-		if previous != nil && previous.value >= *threshold.value {
+		if previous != nil && previous.value > *threshold.value {
 			return fmt.Errorf(
-				"%s threshold must be less than %s threshold for topic %q",
+				"%s threshold must not exceed %s threshold for topic %q",
 				previous.name,
 				threshold.name,
 				signal.Topic,
@@ -366,14 +366,14 @@ func buildCriticalExpression(signal AlertSignal) string {
 
 func buildWarningExpression(signal AlertSignal) string {
 	conditions := make([]string, 0, 2)
-	if signal.WarningLow != nil {
+	if signal.WarningLow != nil && (signal.CriticalLow == nil || *signal.WarningLow != *signal.CriticalLow) {
 		low := "$B <= " + formatThreshold(*signal.WarningLow)
 		if signal.CriticalLow != nil {
 			low = "(" + low + " && $B > " + formatThreshold(*signal.CriticalLow) + ")"
 		}
 		conditions = append(conditions, low)
 	}
-	if signal.WarningHigh != nil {
+	if signal.WarningHigh != nil && (signal.CriticalHigh == nil || *signal.WarningHigh != *signal.CriticalHigh) {
 		high := "$B >= " + formatThreshold(*signal.WarningHigh)
 		if signal.CriticalHigh != nil {
 			high = "(" + high + " && $B < " + formatThreshold(*signal.CriticalHigh) + ")"

--- a/config/alerting_test.go
+++ b/config/alerting_test.go
@@ -47,6 +47,17 @@ func TestBuildAlertProvisioning(t *testing.T) {
 			wantNoDataStates: []string{"NoData"}, wantLookbacks: []int{alertDefaultLookbackSecs}, wantConditions: []string{"$B >= 80"},
 		},
 		{
+			name: "equal critical and warning limits omit empty warning bands",
+			signals: []AlertSignal{{
+				Topic:       "data/powertrain/coolant-temperature",
+				CriticalLow: float64Pointer(0), WarningLow: float64Pointer(0),
+				WarningHigh: float64Pointer(120), CriticalHigh: float64Pointer(120),
+			}},
+			wantRuleCount: 1, wantTopics: []string{"data/powertrain/coolant-temperature"},
+			wantSeverities: []string{"critical"}, wantNoDataStates: []string{"NoData"},
+			wantLookbacks: []int{alertDefaultLookbackSecs}, wantConditions: []string{"($B <= 0 || $B >= 120)"},
+		},
+		{
 			name:          "signals without policies produce no rules",
 			signals:       []AlertSignal{{Topic: "data/interior/ambient-light"}},
 			wantRuleCount: 0,
@@ -69,6 +80,7 @@ func TestBuildAlertProvisioning(t *testing.T) {
 				assert.Equal(t, test.wantSeverities[index], rule.Labels["severity"])
 				assert.Equal(t, test.wantNoDataStates[index], rule.NoDataState)
 				assert.LessOrEqual(t, len(rule.UID), 40)
+				assert.Equal(t, "0s", rule.For)
 				assertAlertData(t, rule, test.wantLookbacks[index], test.wantConditions[index])
 			}
 			if test.wantDashboardUID != "" {
@@ -160,8 +172,7 @@ func TestBuildAlertProvisioningRejectsInvalidSignals(t *testing.T) {
 		{name: "negative stale interval", signals: []AlertSignal{{Topic: "data/a/value", StaleAfterSeconds: intPointer(-1)}}, want: "must be positive"},
 		{name: "NaN threshold", signals: []AlertSignal{{Topic: "data/a/value", CriticalHigh: float64Pointer(math.NaN())}}, want: "must be finite"},
 		{name: "infinite threshold", signals: []AlertSignal{{Topic: "data/a/value", WarningLow: float64Pointer(math.Inf(1))}}, want: "must be finite"},
-		{name: "descending thresholds", signals: []AlertSignal{{Topic: "data/a/value", CriticalLow: float64Pointer(300), WarningLow: float64Pointer(200)}}, want: "critical low threshold must be less than warning low threshold"},
-		{name: "equal thresholds", signals: []AlertSignal{{Topic: "data/a/value", WarningHigh: float64Pointer(100), CriticalHigh: float64Pointer(100)}}, want: "warning high threshold must be less than critical high threshold"},
+		{name: "descending thresholds", signals: []AlertSignal{{Topic: "data/a/value", CriticalLow: float64Pointer(300), WarningLow: float64Pointer(200)}}, want: "critical low threshold must not exceed warning low threshold"},
 	}
 
 	for _, test := range tests {
@@ -184,6 +195,8 @@ func TestAlertExpressions(t *testing.T) {
 		{name: "critical high only", signal: AlertSignal{CriticalHigh: float64Pointer(2e6)}, wantCritical: "$B >= 2e+06"},
 		{name: "both warning bounds", signal: AlertSignal{WarningLow: float64Pointer(-1), WarningHigh: float64Pointer(1)}, wantWarning: "($B <= -1 || $B >= 1)"},
 		{name: "both critical bounds", signal: AlertSignal{CriticalLow: float64Pointer(-2), CriticalHigh: float64Pointer(2)}, wantCritical: "($B <= -2 || $B >= 2)"},
+		{name: "equal low critical and warning limits omit warning low band", signal: AlertSignal{CriticalLow: float64Pointer(-2), WarningLow: float64Pointer(-2)}, wantCritical: "$B <= -2"},
+		{name: "equal high warning and critical limits omit warning high band", signal: AlertSignal{WarningHigh: float64Pointer(2), CriticalHigh: float64Pointer(2)}, wantCritical: "$B >= 2"},
 	}
 
 	for _, test := range tests {

--- a/config/dashboards.go
+++ b/config/dashboards.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/ApexCorse/vera"
 	"github.com/grafana/grafana-foundation-sdk/go/cog"
 	"github.com/grafana/grafana-foundation-sdk/go/common"
 	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
@@ -57,6 +56,14 @@ type topicSignal struct {
 	topic string
 }
 
+// SignalTopic is the topic mapping needed to generate dashboards. It stays
+// local because Vera v0.14 exposes MQTT mappings as signal metadata instead
+// of the former SignalTopic collection.
+type SignalTopic struct {
+	Signal string
+	Topic  string
+}
+
 // alertListOptions mirrors Grafana's native alertlist panel options. It is
 // local because the Foundation SDK does not currently generate this panel.
 type alertListOptions struct {
@@ -82,7 +89,7 @@ type alertListStateFilter struct {
 
 // parseSignalTopicHierarchy groups topics into dashboard sections. A valid topic
 // has a section and signal path after the required data/ prefix.
-func parseSignalTopicHierarchy(signalTopics []vera.SignalTopic) ([]topicSection, error) {
+func parseSignalTopicHierarchy(signalTopics []SignalTopic) ([]topicSection, error) {
 	sectionsByName := make(map[string][]topicSignal)
 	seenTopics := make(map[string]struct{}, len(signalTopics))
 
@@ -286,7 +293,7 @@ func buildSignalDetailDashboard(signal topicSignal) (dashboard.Dashboard, error)
 
 // createDashboardsWithSignalTopics generates a stable overview and one
 // deterministic drill-down dashboard per DBC signal-topic mapping.
-func createDashboardsWithSignalTopics(signalTopics []vera.SignalTopic) (map[string]dashboard.Dashboard, error) {
+func createDashboardsWithSignalTopics(signalTopics []SignalTopic) (map[string]dashboard.Dashboard, error) {
 	sections, err := parseSignalTopicHierarchy(signalTopics)
 	if err != nil {
 		return nil, err

--- a/config/dashboards_test.go
+++ b/config/dashboards_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ApexCorse/vera"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -13,13 +12,13 @@ import (
 func TestCreateDashboardsWithSignalTopics(t *testing.T) {
 	tests := []struct {
 		name       string
-		topics     []vera.SignalTopic
+		topics     []SignalTopic
 		wantCount  int
 		wantPieces []string
 	}{
 		{
 			name: "stable overview and detail dashboards",
-			topics: []vera.SignalTopic{
+			topics: []SignalTopic{
 				{Signal: "OilPressure", Topic: "data/powertrain/engine/oil-pressure"},
 				{Signal: "StateOfCharge", Topic: "data/electrical/battery/state-of-charge"},
 				{Signal: "EngineSpeed", Topic: "data/powertrain/engine-speed"},
@@ -78,23 +77,23 @@ func TestCreateDashboardsWithSignalTopics(t *testing.T) {
 func TestParseSignalTopicHierarchy(t *testing.T) {
 	tests := []struct {
 		name      string
-		topics    []vera.SignalTopic
+		topics    []SignalTopic
 		want      []topicSection
 		wantError string
 	}{
 		{
 			name:   "groups and sorts sections and signals",
-			topics: []vera.SignalTopic{{Topic: "data/z_section/oil_temp"}, {Topic: "data/a-section/wheel-speed"}, {Topic: "data/a-section/brake/pressure"}},
+			topics: []SignalTopic{{Topic: "data/z_section/oil_temp"}, {Topic: "data/a-section/wheel-speed"}, {Topic: "data/a-section/brake/pressure"}},
 			want: []topicSection{
 				{name: "A Section", signals: []topicSignal{{label: "Brake / Pressure", topic: "data/a-section/brake/pressure"}, {label: "Wheel Speed", topic: "data/a-section/wheel-speed"}}},
 				{name: "Z Section", signals: []topicSignal{{label: "Oil Temp", topic: "data/z_section/oil_temp"}}},
 			},
 		},
-		{name: "rejects wrong prefix", topics: []vera.SignalTopic{{Topic: "vehicle/powertrain/engine-speed"}}, wantError: `must start with "data/"`},
-		{name: "rejects missing signal", topics: []vera.SignalTopic{{Topic: "data/powertrain"}}, wantError: "section and signal"},
-		{name: "rejects empty section", topics: []vera.SignalTopic{{Topic: "data//engine-speed"}}, wantError: "levels cannot be empty"},
-		{name: "rejects empty signal", topics: []vera.SignalTopic{{Topic: "data/powertrain/"}}, wantError: "levels cannot be empty"},
-		{name: "rejects duplicate", topics: []vera.SignalTopic{{Topic: "data/powertrain/engine-speed"}, {Topic: "data/powertrain/engine-speed"}}, wantError: "duplicate topic"},
+		{name: "rejects wrong prefix", topics: []SignalTopic{{Topic: "vehicle/powertrain/engine-speed"}}, wantError: `must start with "data/"`},
+		{name: "rejects missing signal", topics: []SignalTopic{{Topic: "data/powertrain"}}, wantError: "section and signal"},
+		{name: "rejects empty section", topics: []SignalTopic{{Topic: "data//engine-speed"}}, wantError: "levels cannot be empty"},
+		{name: "rejects empty signal", topics: []SignalTopic{{Topic: "data/powertrain/"}}, wantError: "levels cannot be empty"},
+		{name: "rejects duplicate", topics: []SignalTopic{{Topic: "data/powertrain/engine-speed"}, {Topic: "data/powertrain/engine-speed"}}, wantError: "duplicate topic"},
 	}
 
 	for _, test := range tests {

--- a/config/go.mod
+++ b/config/go.mod
@@ -2,7 +2,7 @@ module github.com/ApexCorse/ephoros/config
 
 go 1.25.1
 
-require github.com/ApexCorse/vera v0.13.0
+require github.com/ApexCorse/vera v0.14.0
 
 require github.com/grafana/grafana-foundation-sdk/go v0.0.0-20251008104357-2e5c9f991a96
 

--- a/config/go.sum
+++ b/config/go.sum
@@ -1,5 +1,5 @@
-github.com/ApexCorse/vera v0.13.0 h1:HbPcwrwgoAvNh0iH4s/St2wL1/pBYh/RjH8FGcp1Heg=
-github.com/ApexCorse/vera v0.13.0/go.mod h1:WGkLG8x6U4B3Fhnr4k3at0Ebam6qHBbUR9x57L6SBv8=
+github.com/ApexCorse/vera v0.14.0 h1:BHkggNAa9nt3FT61rM1WdDifCaB8Q6fnrz2d9v3k4Cw=
+github.com/ApexCorse/vera v0.14.0/go.mod h1:WGkLG8x6U4B3Fhnr4k3at0Ebam6qHBbUR9x57L6SBv8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/grafana/grafana-foundation-sdk/go v0.0.0-20251008104357-2e5c9f991a96 h1:dWUMXBaBDpiLYDWlxHQIFySY/+r3ekjupiqEPVWvTWE=

--- a/config/main.go
+++ b/config/main.go
@@ -17,6 +17,11 @@ func main() {
 		fmt.Println("missing env DASHBOARDS_PATH")
 		os.Exit(1)
 	}
+	alertsPath := os.Getenv("ALERTS_PATH")
+	if alertsPath == "" {
+		fmt.Println("missing env ALERTS_PATH")
+		os.Exit(1)
+	}
 	preconfigGrafana()
 
 	if err := cleanProvisioningFolder(dashboardsPath); err != nil {
@@ -28,6 +33,10 @@ func main() {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}
+	if err := cleanProvisioningFolder(alertsPath); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
 
 	config, err := getDbcConfig()
 	if err != nil {
@@ -35,7 +44,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	dashboards, err := createDashboardsWithSignalTopics(config.Topics)
+	signalTopics, alertSignals, err := signalsFromMetadata(config)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	dashboards, err := createDashboardsWithSignalTopics(signalTopics)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
@@ -65,6 +80,11 @@ func main() {
 			fmt.Println(err.Error())
 			os.Exit(1)
 		}
+	}
+
+	if err := WriteAlertProvisioning(filepath.Join(alertsPath, "alerts.json"), alertSignals); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
 	}
 }
 

--- a/config/main_test.go
+++ b/config/main_test.go
@@ -15,7 +15,8 @@ BS_:
 BU_: ECU
 BO_ 256 Powertrain: 8 ECU
  SG_ EngineSpeed : 0|16@1+ (1,0) [0|100] "rpm" ECU
-CM_ SG_ 256 EngineSpeed "vera:mqtt-topic=data/powertrain/engine-speed";
+BA_DEF_ SG_ "VeraMqttTopic" STRING ;
+BA_ "VeraMqttTopic" SG_ 256 EngineSpeed "data/powertrain/engine-speed";
 `
 
 func TestGetDbcConfig(t *testing.T) {
@@ -67,8 +68,10 @@ func TestGetDbcConfig(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.NotNil(t, config)
-			assert.Len(t, config.Topics, test.wantTopics)
-			assert.Equal(t, "data/powertrain/engine-speed", config.Topics[0].Topic)
+			topics, _, err := signalsFromMetadata(config)
+			require.NoError(t, err)
+			assert.Len(t, topics, test.wantTopics)
+			assert.Equal(t, "data/powertrain/engine-speed", topics[0].Topic)
 		})
 	}
 }

--- a/config/signal_metadata.go
+++ b/config/signal_metadata.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ApexCorse/vera"
+)
+
+// signalsFromMetadata converts Vera's signal-scoped metadata into the compact
+// inputs consumed by dashboard and alert provisioning. Signals without an MQTT
+// topic are irrelevant to Grafana unless they define an alert or stale policy;
+// in that case failing is safer than silently omitting the policy.
+func signalsFromMetadata(config *vera.Config) ([]SignalTopic, []AlertSignal, error) {
+	if config == nil {
+		return nil, nil, fmt.Errorf("Vera config cannot be nil")
+	}
+
+	topics := make([]SignalTopic, 0)
+	alerts := make([]AlertSignal, 0)
+	for _, message := range config.Messages {
+		for _, signal := range message.Signals {
+			metadata := signal.Metadata
+			hasAlertPolicy := metadata.WarningLow != nil ||
+				metadata.WarningHigh != nil ||
+				metadata.CriticalLow != nil ||
+				metadata.CriticalHigh != nil ||
+				metadata.StaleAfterMs != nil
+			topic := strings.TrimSpace(metadata.MQTTTopic)
+
+			if topic == "" {
+				if hasAlertPolicy {
+					return nil, nil, fmt.Errorf(
+						"signal %q in message %q defines alert metadata but has no MQTT topic",
+						signal.Name,
+						message.Name,
+					)
+				}
+				continue
+			}
+
+			topics = append(topics, SignalTopic{Topic: topic})
+			if !hasAlertPolicy {
+				continue
+			}
+
+			alerts = append(alerts, AlertSignal{
+				Topic:             topic,
+				WarningLow:        float64PointerFromFloat32(metadata.WarningLow),
+				WarningHigh:       float64PointerFromFloat32(metadata.WarningHigh),
+				CriticalLow:       float64PointerFromFloat32(metadata.CriticalLow),
+				CriticalHigh:      float64PointerFromFloat32(metadata.CriticalHigh),
+				StaleAfterSeconds: staleAfterSeconds(metadata.StaleAfterMs),
+				DashboardUID:      detailDashboardKey(topic),
+				PanelID:           int(stablePanelID(topic, 'D')),
+			})
+		}
+	}
+
+	return topics, alerts, nil
+}
+
+func float64PointerFromFloat32(value *float32) *float64 {
+	if value == nil {
+		return nil
+	}
+	converted := float64(*value)
+	return &converted
+}
+
+// staleAfterSeconds rounds upward so that Grafana never considers a signal
+// stale sooner than the DBC's millisecond policy permits.
+func staleAfterSeconds(milliseconds *uint32) *int {
+	if milliseconds == nil {
+		return nil
+	}
+	seconds := int(*milliseconds / 1000)
+	if *milliseconds%1000 != 0 {
+		seconds++
+	}
+	return &seconds
+}

--- a/config/signal_metadata_test.go
+++ b/config/signal_metadata_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/ApexCorse/vera"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func float32PointerForMetadata(value float32) *float32 { return &value }
+func uint32PointerForMetadata(value uint32) *uint32    { return &value }
+func intPointerForMetadata(value int) *int             { return &value }
+
+func TestSignalsFromMetadata(t *testing.T) {
+	config := &vera.Config{Messages: []vera.Message{{
+		Name: "Powertrain",
+		Signals: []vera.Signal{
+			{
+				Name: "EngineSpeed",
+				Metadata: vera.SignalMetadata{
+					MQTTTopic:    "data/powertrain/engine-speed",
+					WarningLow:   float32PointerForMetadata(600),
+					WarningHigh:  float32PointerForMetadata(6500),
+					CriticalLow:  float32PointerForMetadata(300),
+					CriticalHigh: float32PointerForMetadata(7000),
+					StaleAfterMs: uint32PointerForMetadata(250),
+				},
+			},
+			{
+				Name:     "AmbientLight",
+				Metadata: vera.SignalMetadata{MQTTTopic: "data/interior/ambient-light"},
+			},
+			{Name: "Unpublished"},
+		},
+	}}}
+
+	topics, alerts, err := signalsFromMetadata(config)
+	require.NoError(t, err)
+	assert.Equal(t, []SignalTopic{
+		{Topic: "data/powertrain/engine-speed"},
+		{Topic: "data/interior/ambient-light"},
+	}, topics)
+	require.Len(t, alerts, 1)
+	assert.Equal(t, "data/powertrain/engine-speed", alerts[0].Topic)
+	require.NotNil(t, alerts[0].WarningLow)
+	assert.Equal(t, 600.0, *alerts[0].WarningLow)
+	require.NotNil(t, alerts[0].WarningHigh)
+	assert.Equal(t, 6500.0, *alerts[0].WarningHigh)
+	require.NotNil(t, alerts[0].CriticalLow)
+	assert.Equal(t, 300.0, *alerts[0].CriticalLow)
+	require.NotNil(t, alerts[0].CriticalHigh)
+	assert.Equal(t, 7000.0, *alerts[0].CriticalHigh)
+	require.NotNil(t, alerts[0].StaleAfterSeconds)
+	assert.Equal(t, 1, *alerts[0].StaleAfterSeconds)
+	assert.Equal(t, detailDashboardKey("data/powertrain/engine-speed"), alerts[0].DashboardUID)
+	assert.Equal(t, int(stablePanelID("data/powertrain/engine-speed", 'D')), alerts[0].PanelID)
+}
+
+func TestSignalsFromMetadataRejectsPolicyWithoutTopic(t *testing.T) {
+	config := &vera.Config{Messages: []vera.Message{{
+		Name: "Powertrain",
+		Signals: []vera.Signal{{
+			Name:     "EngineSpeed",
+			Metadata: vera.SignalMetadata{StaleAfterMs: uint32PointerForMetadata(1000)},
+		}},
+	}}}
+
+	_, _, err := signalsFromMetadata(config)
+	require.EqualError(t, err, `signal "EngineSpeed" in message "Powertrain" defines alert metadata but has no MQTT topic`)
+}
+
+func TestStaleAfterSecondsRoundsUp(t *testing.T) {
+	tests := []struct {
+		milliseconds *uint32
+		want         *int
+	}{
+		{nil, nil},
+		{uint32PointerForMetadata(1), intPointerForMetadata(1)},
+		{uint32PointerForMetadata(1000), intPointerForMetadata(1)},
+		{uint32PointerForMetadata(1001), intPointerForMetadata(2)},
+		{uint32PointerForMetadata(^uint32(0)), intPointerForMetadata(4294968)},
+	}
+
+	for _, test := range tests {
+		got := staleAfterSeconds(test.milliseconds)
+		assert.Equal(t, test.want, got)
+	}
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,7 @@ services:
     environment:
       - DBC_FILE_PATH=/opt/config.dbc
       - DASHBOARDS_PATH=/opt/grafana/provisioning/dashboards/
+      - ALERTS_PATH=/opt/grafana/provisioning/alerting/
       - INFLUXDB_INIT_BUCKET=${INFLUXDB_INIT_BUCKET:-telemetry}
   broker:
     image: emqx/emqx-enterprise:5.10.0

--- a/simulator/go.mod
+++ b/simulator/go.mod
@@ -3,7 +3,7 @@ module github.com/ApexCorse/ephoros/simulator
 go 1.25.1
 
 require (
-	github.com/ApexCorse/vera v0.13.0
+	github.com/ApexCorse/vera v0.14.0
 	github.com/eclipse/paho.golang v0.23.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/simulator/go.sum
+++ b/simulator/go.sum
@@ -1,7 +1,5 @@
-github.com/ApexCorse/vera v0.0.0-20251030092832-2a4b5b476f0d h1:DtLm7MoKpy6MKmuSngODcMUDK3y/kVLemuwWnpGD5OU=
-github.com/ApexCorse/vera v0.0.0-20251030092832-2a4b5b476f0d/go.mod h1:WGkLG8x6U4B3Fhnr4k3at0Ebam6qHBbUR9x57L6SBv8=
-github.com/ApexCorse/vera v0.13.0 h1:HbPcwrwgoAvNh0iH4s/St2wL1/pBYh/RjH8FGcp1Heg=
-github.com/ApexCorse/vera v0.13.0/go.mod h1:WGkLG8x6U4B3Fhnr4k3at0Ebam6qHBbUR9x57L6SBv8=
+github.com/ApexCorse/vera v0.14.0 h1:BHkggNAa9nt3FT61rM1WdDifCaB8Q6fnrz2d9v3k4Cw=
+github.com/ApexCorse/vera v0.14.0/go.mod h1:WGkLG8x6U4B3Fhnr4k3at0Ebam6qHBbUR9x57L6SBv8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.golang v0.23.0 h1:KHgl2wz6EJo7cMBmkuhpt7C576vP+kpPv7jjvSyR6Mk=

--- a/simulator/main.go
+++ b/simulator/main.go
@@ -201,9 +201,13 @@ func writeTopicCatalog(outputPath string, topics []string) error {
 
 // getTopicsFromConfig extracts MQTT topics from the vera config
 func getTopicsFromConfig(config *vera.Config) []string {
-	topics := make([]string, len(config.Topics))
-	for i := range config.Topics {
-		topics[i] = config.Topics[i].Topic
+	topics := make([]string, 0)
+	for _, message := range config.Messages {
+		for _, signal := range message.Signals {
+			if topic := signal.Metadata.MQTTTopic; topic != "" {
+				topics = append(topics, topic)
+			}
+		}
 	}
 
 	return topics

--- a/simulator/main_test.go
+++ b/simulator/main_test.go
@@ -14,7 +14,8 @@ import (
 
 const validDBC = `BO_ 123 Vehicle: 8 ECU
 	SG_ Speed : 0|16@1+ (0.1,0) [0|100] "km/h" Gateway
-CM_ SG_ 123 Speed "vera:mqtt-topic=vehicle/speed";`
+BA_DEF_ SG_ "VeraMqttTopic" STRING ;
+BA_ "VeraMqttTopic" SG_ 123 Speed "vehicle/speed";`
 
 func TestGenerateRandomData(t *testing.T) {
 	tests := []struct {
@@ -167,11 +168,16 @@ func TestGetTopicsFromConfig(t *testing.T) {
 	}{
 		{name: "empty", config: &vera.Config{}, want: []string{}},
 		{
-			name: "preserves topic order and duplicates",
-			config: &vera.Config{Topics: []vera.SignalTopic{
-				{MessageID: 1, Signal: "Speed", Topic: "vehicle/speed"},
-				{MessageID: 2, Signal: "Voltage", Topic: "vehicle/voltage"},
-				{MessageID: 3, Signal: "SpeedBackup", Topic: "vehicle/speed"},
+			name: "preserves message and signal order, duplicates, and skips empty topics",
+			config: &vera.Config{Messages: []vera.Message{
+				{Signals: []vera.Signal{
+					{Name: "Speed", Metadata: vera.SignalMetadata{MQTTTopic: "vehicle/speed"}},
+					{Name: "NoTopic"},
+					{Name: "Voltage", Metadata: vera.SignalMetadata{MQTTTopic: "vehicle/voltage"}},
+				}},
+				{Signals: []vera.Signal{
+					{Name: "SpeedBackup", Metadata: vera.SignalMetadata{MQTTTopic: "vehicle/speed"}},
+				}},
 			}},
 			want: []string{"vehicle/speed", "vehicle/voltage", "vehicle/speed"},
 		},


### PR DESCRIPTION
## Summary

- Upgrade Vera to v0.14 and read signal-scoped MQTT and alert metadata.
- Provision Grafana dashboards and alerts from DBC signal definitions.
- Add alert validation for equal thresholds and round stale intervals upward.
- Update simulator topic extraction and Docker Compose alert provisioning configuration.

## Testing

- Added coverage for signal metadata conversion and missing-topic validation.
- Added alert expression, threshold, dashboard, and stale-interval tests.
- Updated simulator and DBC configuration tests for Vera v0.14 metadata.