### PR TITLE
fix: ignore provisioned Grafana alert files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 **/.vscode/settings.json
 
 grafana/provisioning/dashboards/
+grafana/provisioning/alerting/
 config.dbc
 embedded/src/telemetry_catalog.h


### PR DESCRIPTION
## Summary
- Ignore provisioned Grafana alerting files in Git.

## Testing
- Not run (configuration-only change).