### PR TITLE
feat: group telemetry panels by module

### DIFF
--- a/config/dashboards.go
+++ b/config/dashboards.go
@@ -49,11 +49,18 @@ var (
 type topicSection struct {
 	name    string
 	signals []topicSignal
+	modules []topicModule
 }
 
 type topicSignal struct {
-	label string
-	topic string
+	label       string
+	detailLabel string
+	topic       string
+}
+
+type topicModule struct {
+	name    string
+	signals []topicSignal
 }
 
 // SignalTopic is the topic mapping needed to generate dashboards. It stays
@@ -88,9 +95,15 @@ type alertListStateFilter struct {
 }
 
 // parseSignalTopicHierarchy groups topics into dashboard sections. A valid topic
-// has a section and signal path after the required data/ prefix.
+// has either a section and signal or a section, module, and signal after the
+// required data/ prefix.
 func parseSignalTopicHierarchy(signalTopics []SignalTopic) ([]topicSection, error) {
-	sectionsByName := make(map[string][]topicSignal)
+	type sectionContents struct {
+		signals       []topicSignal
+		modulesByName map[string][]topicSignal
+	}
+
+	sectionsByName := make(map[string]sectionContents)
 	seenTopics := make(map[string]struct{}, len(signalTopics))
 
 	for _, signalTopic := range signalTopics {
@@ -100,8 +113,8 @@ func parseSignalTopicHierarchy(signalTopics []SignalTopic) ([]topicSection, erro
 		}
 
 		parts := strings.Split(strings.TrimPrefix(topic, topicPrefix), "/")
-		if len(parts) < 2 {
-			return nil, fmt.Errorf("topic must have a section and signal after %q: %s", topicPrefix, topic)
+		if len(parts) != 2 && len(parts) != 3 {
+			return nil, fmt.Errorf("topic must have a section and signal, optionally preceded by one module, after %q: %s", topicPrefix, topic)
 		}
 		for _, part := range parts {
 			if part == "" {
@@ -114,25 +127,46 @@ func parseSignalTopicHierarchy(signalTopics []SignalTopic) ([]topicSection, erro
 		seenTopics[topic] = struct{}{}
 
 		section := parts[0]
-		sectionsByName[section] = append(sectionsByName[section], topicSignal{
-			label: humanizeTopicPath(parts[1:]),
-			topic: topic,
-		})
+		contents := sectionsByName[section]
+		signal := topicSignal{
+			label:       humanizeTopicSegment(parts[len(parts)-1]),
+			detailLabel: humanizeTopicPath(parts[1:]),
+			topic:       topic,
+		}
+		if len(parts) == 2 {
+			contents.signals = append(contents.signals, signal)
+		} else {
+			if contents.modulesByName == nil {
+				contents.modulesByName = make(map[string][]topicSignal)
+			}
+			contents.modulesByName[parts[1]] = append(contents.modulesByName[parts[1]], signal)
+		}
+		sectionsByName[section] = contents
 	}
 
 	sections := make([]topicSection, 0, len(sectionsByName))
-	for name, signals := range sectionsByName {
-		sort.Slice(signals, func(i, j int) bool {
-			if signals[i].label == signals[j].label {
-				return signals[i].topic < signals[j].topic
-			}
-			return signals[i].label < signals[j].label
-		})
-		sections = append(sections, topicSection{name: humanizeTopicSegment(name), signals: signals})
+	for name, contents := range sectionsByName {
+		sortTopicSignals(contents.signals)
+		var modules []topicModule
+		for moduleName, signals := range contents.modulesByName {
+			sortTopicSignals(signals)
+			modules = append(modules, topicModule{name: humanizeTopicSegment(moduleName), signals: signals})
+		}
+		sort.Slice(modules, func(i, j int) bool { return modules[i].name < modules[j].name })
+		sections = append(sections, topicSection{name: humanizeTopicSegment(name), signals: contents.signals, modules: modules})
 	}
 	sort.Slice(sections, func(i, j int) bool { return sections[i].name < sections[j].name })
 
 	return sections, nil
+}
+
+func sortTopicSignals(signals []topicSignal) {
+	sort.Slice(signals, func(i, j int) bool {
+		if signals[i].label == signals[j].label {
+			return signals[i].topic < signals[j].topic
+		}
+		return signals[i].label < signals[j].label
+	})
 }
 
 func humanizeTopicPath(parts []string) string {
@@ -233,36 +267,46 @@ func buildTelemetryDashboard(sections []topicSection) (dashboard.Dashboard, erro
 	for _, section := range sections {
 		builder = builder.WithRow(dashboard.NewRowBuilder(section.name).Collapsed(false))
 		for _, signal := range section.signals {
-			builder = builder.WithPanel(
-				stat.NewPanelBuilder().
-					Id(stablePanelID(signal.topic, 'l')).
-					Title(signal.label + " (live)").
-					Span(12).
-					GraphMode(common.BigValueGraphModeArea).
-					NoValue("No data").
-					Datasource(dataSourceRef).
-					DataLinks([]cog.Builder[dashboard.DashboardLink]{detailDashboardLink(signal.topic)}).
-					WithTarget(NewMQTTQueryBuilder(signal.topic)),
-			).WithPanel(
-				timeseries.NewPanelBuilder().
-					Id(stablePanelID(signal.topic, 'h')).
-					Title(signal.label + " (history)").
-					Span(12).
-					Datasource(influxDBDataSourceRef).
-					DataLinks([]cog.Builder[dashboard.DashboardLink]{detailDashboardLink(signal.topic)}).
-					WithTarget(NewInfluxDBQueryBuilder(signal.topic)),
-			)
+			builder = addTelemetrySignalPanels(builder, signal, 12)
+		}
+		for _, module := range section.modules {
+			builder = builder.WithRow(dashboard.NewRowBuilder(module.name).Collapsed(false))
+			for _, signal := range module.signals {
+				builder = addTelemetrySignalPanels(builder, signal, 6)
+			}
 		}
 	}
 
 	return builder.Build()
 }
 
+func addTelemetrySignalPanels(builder *dashboard.DashboardBuilder, signal topicSignal, span uint32) *dashboard.DashboardBuilder {
+	return builder.WithPanel(
+		stat.NewPanelBuilder().
+			Id(stablePanelID(signal.topic, 'l')).
+			Title(signal.label + " (live)").
+			Span(span).
+			GraphMode(common.BigValueGraphModeArea).
+			NoValue("No data").
+			Datasource(dataSourceRef).
+			DataLinks([]cog.Builder[dashboard.DashboardLink]{detailDashboardLink(signal.topic)}).
+			WithTarget(NewMQTTQueryBuilder(signal.topic)),
+	).WithPanel(
+		timeseries.NewPanelBuilder().
+			Id(stablePanelID(signal.topic, 'h')).
+			Title(signal.label + " (history)").
+			Span(span).
+			Datasource(influxDBDataSourceRef).
+			DataLinks([]cog.Builder[dashboard.DashboardLink]{detailDashboardLink(signal.topic)}).
+			WithTarget(NewInfluxDBQueryBuilder(signal.topic)),
+	)
+}
+
 // buildSignalDetailDashboard creates a dedicated, literal-topic dashboard.
 // MQTT targets do not support dashboard template variable interpolation, so a
 // dashboard per topic preserves the exact subscription and query filter.
 func buildSignalDetailDashboard(signal topicSignal) (dashboard.Dashboard, error) {
-	return dashboard.NewDashboardBuilder(signal.label+detailTitleSuffix).
+	return dashboard.NewDashboardBuilder(signal.detailLabel+detailTitleSuffix).
 		Uid(detailDashboardKey(signal.topic)).
 		Description("MQTT topic: "+signal.topic).
 		Refresh("1s").
@@ -271,7 +315,7 @@ func buildSignalDetailDashboard(signal topicSignal) (dashboard.Dashboard, error)
 		WithPanel(
 			stat.NewPanelBuilder().
 				Id(stablePanelID(signal.topic, 'd')).
-				Title(signal.label + " (live)").
+				Title(signal.detailLabel + " (live)").
 				Description("Latest value from MQTT topic: " + signal.topic).
 				Span(24).
 				GraphMode(common.BigValueGraphModeArea).
@@ -282,7 +326,7 @@ func buildSignalDetailDashboard(signal topicSignal) (dashboard.Dashboard, error)
 		WithPanel(
 			timeseries.NewPanelBuilder().
 				Id(stablePanelID(signal.topic, 'D')).
-				Title(signal.label + " (history)").
+				Title(signal.detailLabel + " (history)").
 				Description("24-hour InfluxDB history for MQTT topic: " + signal.topic).
 				Span(24).
 				Datasource(influxDBDataSourceRef).
@@ -312,6 +356,15 @@ func createDashboardsWithSignalTopics(signalTopics []SignalTopic) (map[string]da
 				return nil, fmt.Errorf("build detail dashboard for %q: %w", signal.topic, err)
 			}
 			dashboards[detailDashboardKey(signal.topic)] = detailDashboard
+		}
+		for _, module := range section.modules {
+			for _, signal := range module.signals {
+				detailDashboard, err := buildSignalDetailDashboard(signal)
+				if err != nil {
+					return nil, fmt.Errorf("build detail dashboard for %q: %w", signal.topic, err)
+				}
+				dashboards[detailDashboardKey(signal.topic)] = detailDashboard
+			}
 		}
 	}
 

--- a/config/dashboards_test.go
+++ b/config/dashboards_test.go
@@ -28,8 +28,8 @@ func TestCreateDashboardsWithSignalTopics(t *testing.T) {
 				`"uid":"generated-telemetry"`, `"refresh":"1s"`, `"from":"now-15m"`, `"type":"alertlist"`,
 				`"title":"Active Alerts"`, `"viewMode":"list"`, `"dashboardAlerts":true`,
 				`"stateFilter":{"firing":true,"pending":true,"recovering":false,"noData":true,"normal":false,"error":true}`,
-				`"title":"Electrical"`, `"title":"Powertrain"`, `"title":"Battery / State Of Charge (live)"`,
-				`"title":"Engine / Oil Pressure (history)"`, `"title":"Engine Speed (live)"`,
+				`"title":"Electrical"`, `"title":"Battery"`, `"title":"State Of Charge (live)"`,
+				`"title":"Powertrain"`, `"title":"Engine"`, `"title":"Oil Pressure (history)"`, `"title":"Engine Speed (live)"`,
 				"grafana-mqtt-datasource", "influxdb-datasource", `"graphMode":"area"`, `"noValue":"No data"`,
 				`"collapsed":false`, `"title":"Open detail"`, `from=${__from}\u0026to=${__to}`,
 			},
@@ -85,12 +85,13 @@ func TestParseSignalTopicHierarchy(t *testing.T) {
 			name:   "groups and sorts sections and signals",
 			topics: []SignalTopic{{Topic: "data/z_section/oil_temp"}, {Topic: "data/a-section/wheel-speed"}, {Topic: "data/a-section/brake/pressure"}},
 			want: []topicSection{
-				{name: "A Section", signals: []topicSignal{{label: "Brake / Pressure", topic: "data/a-section/brake/pressure"}, {label: "Wheel Speed", topic: "data/a-section/wheel-speed"}}},
-				{name: "Z Section", signals: []topicSignal{{label: "Oil Temp", topic: "data/z_section/oil_temp"}}},
+				{name: "A Section", signals: []topicSignal{{label: "Wheel Speed", detailLabel: "Wheel Speed", topic: "data/a-section/wheel-speed"}}, modules: []topicModule{{name: "Brake", signals: []topicSignal{{label: "Pressure", detailLabel: "Brake / Pressure", topic: "data/a-section/brake/pressure"}}}}},
+				{name: "Z Section", signals: []topicSignal{{label: "Oil Temp", detailLabel: "Oil Temp", topic: "data/z_section/oil_temp"}}},
 			},
 		},
 		{name: "rejects wrong prefix", topics: []SignalTopic{{Topic: "vehicle/powertrain/engine-speed"}}, wantError: `must start with "data/"`},
 		{name: "rejects missing signal", topics: []SignalTopic{{Topic: "data/powertrain"}}, wantError: "section and signal"},
+		{name: "rejects more than one module", topics: []SignalTopic{{Topic: "data/powertrain/engine/cooling/temperature"}}, wantError: "optionally preceded by one module"},
 		{name: "rejects empty section", topics: []SignalTopic{{Topic: "data//engine-speed"}}, wantError: "levels cannot be empty"},
 		{name: "rejects empty signal", topics: []SignalTopic{{Topic: "data/powertrain/"}}, wantError: "levels cannot be empty"},
 		{name: "rejects duplicate", topics: []SignalTopic{{Topic: "data/powertrain/engine-speed"}, {Topic: "data/powertrain/engine-speed"}}, wantError: "duplicate topic"},
@@ -107,6 +108,53 @@ func TestParseSignalTopicHierarchy(t *testing.T) {
 			assert.Equal(t, test.want, got)
 		})
 	}
+}
+
+func TestBuildTelemetryDashboardUsesCompactModuleGrid(t *testing.T) {
+	sections, err := parseSignalTopicHierarchy([]SignalTopic{
+		{Topic: "data/battery/voltage"},
+		{Topic: "data/battery/m1/s3"},
+		{Topic: "data/battery/m1/s1"},
+		{Topic: "data/battery/m1/s2"},
+	})
+	require.NoError(t, err)
+
+	telemetry, err := buildTelemetryDashboard(sections)
+	require.NoError(t, err)
+	encoded, err := json.Marshal(telemetry)
+	require.NoError(t, err)
+
+	type gridPos struct {
+		W int `json:"w"`
+		X int `json:"x"`
+	}
+	type panel struct {
+		Type    string  `json:"type"`
+		Title   string  `json:"title"`
+		GridPos gridPos `json:"gridPos"`
+	}
+	var generated struct {
+		Panels []panel `json:"panels"`
+	}
+	require.NoError(t, json.Unmarshal(encoded, &generated))
+
+	panelsByTitle := make(map[string]panel, len(generated.Panels))
+	panelIndexes := make(map[string]int, len(generated.Panels))
+	for index, panel := range generated.Panels {
+		panelsByTitle[panel.Title] = panel
+		panelIndexes[panel.Title] = index
+	}
+	assert.Equal(t, "row", panelsByTitle["Battery"].Type)
+	assert.Equal(t, "row", panelsByTitle["M1"].Type)
+	assert.Equal(t, gridPos{W: 12, X: 0}, panelsByTitle["Voltage (live)"].GridPos)
+	assert.Equal(t, gridPos{W: 12, X: 12}, panelsByTitle["Voltage (history)"].GridPos)
+	assert.Equal(t, gridPos{W: 6, X: 0}, panelsByTitle["S1 (live)"].GridPos)
+	assert.Equal(t, gridPos{W: 6, X: 6}, panelsByTitle["S1 (history)"].GridPos)
+	assert.Equal(t, gridPos{W: 6, X: 12}, panelsByTitle["S2 (live)"].GridPos)
+	assert.Equal(t, gridPos{W: 6, X: 18}, panelsByTitle["S2 (history)"].GridPos)
+	assert.Equal(t, gridPos{W: 6, X: 0}, panelsByTitle["S3 (live)"].GridPos)
+	assert.Equal(t, gridPos{W: 6, X: 6}, panelsByTitle["S3 (history)"].GridPos)
+	assert.Less(t, panelIndexes["Voltage (live)"], panelIndexes["M1"])
 }
 
 func TestHumanizeTopicSegment(t *testing.T) {


### PR DESCRIPTION
## Summary

- Group nested telemetry topics into module-specific dashboard rows.
- Use compact two-column live/history panels for module signals.
- Preserve detailed topic labels and generate detail dashboards for module signals.
- Add coverage for module parsing, sorting, layout, and validation.

## Testing

- Added and updated dashboard generation tests in `config/dashboards_test.go`.
- Verified module grid positions and rejection of topics with multiple module levels.