### PR TITLE
chore(embedded): ignore generated simulator files

### DIFF
--- a/embedded/.gitignore
+++ b/embedded/.gitignore
@@ -4,3 +4,5 @@
 .vscode/launch.json
 .vscode/ipch
 compile_commands.json
+src/catalog.h
+generated/


### PR DESCRIPTION
## Summary

- Ignore the generated simulator catalog and output directory in the embedded project.
- Prevent generated files from being tracked by source control.

## Testing

- Not run (ignore-only change).