### PR TITLE
fix(embedded): configure 2 MiB flash size

### DIFF
--- a/embedded/platformio.ini
+++ b/embedded/platformio.ini
@@ -12,5 +12,9 @@
 platform = espressif32@7.0.1
 board = esp32dev
 framework = espidf
+; The installed ESP32 module has a 2 MiB SPI flash chip.  Override the
+; generic esp32dev profile (4 MiB) so ESP-IDF generates a matching image.
+board_upload.flash_size = 2MB
+board_upload.maximum_size = 2097152
 ; Keep local Menuconfig changes out of the tracked sdkconfig.esp32dev file.
 board_build.esp-idf.sdkconfig_path = sdkconfig.esp32dev.private


### PR DESCRIPTION
## Summary
- Configure the embedded target for 2 MiB flash memory.
- Update the MQTT integration to use the ESP-IDF component dependency.
- Simplify MQTT client setup and telemetry payload generation.

## Testing
- Not run.